### PR TITLE
Create HTML export from Hoedown output.

### DIFF
--- a/src/entities/note.h
+++ b/src/entities/note.h
@@ -88,7 +88,7 @@ public:
 
     bool remove(bool withFile);
 
-    QString toMarkdownHtml(QString notesPath, int maxImageWidth = 980);
+    QString toMarkdownHtml(QString notesPath, int maxImageWidth = 980, bool forExport = false);
 
     bool isFetched();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2119,13 +2119,10 @@ void MainWindow::askForEncryptedNotePasswordIfNeeded(QString additionalText) {
 }
 
 /**
- * Sets the note text according to a note
+ * Gets the maximum image width
  */
-void MainWindow::setNoteTextFromNote(Note *note, bool updateNoteTextViewOnly) {
-    if (!updateNoteTextViewOnly) {
-        ui->noteTextEdit->setText(note->getNoteText());
-    }
-
+int MainWindow::getMaxImageWidth()
+{
     QMargins margins = ui->noteTextView->contentsMargins();
     int maxImageWidth = ui->noteTextView->viewport()->width() - margins.left()
                         - margins.right() - 15;
@@ -2134,8 +2131,19 @@ void MainWindow::setNoteTextFromNote(Note *note, bool updateNoteTextViewOnly) {
         maxImageWidth = 16;
     }
 
+    return maxImageWidth;
+}
+
+/**
+ * Sets the note text according to a note
+ */
+void MainWindow::setNoteTextFromNote(Note *note, bool updateNoteTextViewOnly) {
+    if (!updateNoteTextViewOnly) {
+        ui->noteTextEdit->setText(note->getNoteText());
+    }
+
     ui->noteTextView->setHtml(
-            note->toMarkdownHtml(notesPath, maxImageWidth));
+            note->toMarkdownHtml(notesPath, getMaxImageWidth()));
 
     // update the slider when editing notes
     noteTextSliderValueChanged(
@@ -5242,7 +5250,7 @@ void MainWindow::on_actionExport_preview_HTML_triggered() {
             }
             QTextStream out(&file);
             out.setCodec("UTF-8");
-            out << ui->noteTextView->toHtml();
+            out << currentNote.toMarkdownHtml(notesPath, getMaxImageWidth(), true);
             file.flush();
             file.close();
         }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -487,4 +487,6 @@ private:
     void showLogDialog();
 
     void initLogDialog() const;
+
+    int getMaxImageWidth();
 };


### PR DESCRIPTION
Pull request for https://github.com/pbek/QOwnNotes/issues/168

Create HTML export output via `Note::toMarkdownHtml()` instead of exporting the content of the note preview as HTML. 

The change turned out to be a bit more invasive than I expected. To allow greatest flexibility for customizing the export stylesheet independently of the preview stylesheet while still keeping code duplication minimal the best solution I could come up with quickly was to extend the stylesheet creation code in `toMarkdownHtml` and add an additional parameter `forExport` (default: `false`) which defines whether the function is used in the preview or export context. I'd be happy to learn about better ways to implement this.

With the ability to adapt the CSS of the export easily, this implementation provides two additional features compared to yesterday's proof-of-concept:

- the font configured in property `MainWindow/noteTextView.font` is used as the font for the body of the exported HTML
- `maxImageWidth` is ignored if `forExport` is true; instead images are exported  with style `max-width: 100%;` to reduce their width if they're wider than the browser window