### PR TITLE
Decreased default size of todo dialog

### DIFF
--- a/src/dialogs/tododialog.ui
+++ b/src/dialogs/tododialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1289</width>
-    <height>977</height>
+    <width>792</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
Decreased default size of todo dialog because on small screens e.g. with resolution of 1360x768 using the window manager i3 the dialog was not fully visible.