### PR TITLE
Add missing headers to allow build with USE_SYSTEM_BOTAN=1 to succeed

### DIFF
--- a/src/libraries/botan/botan.h
+++ b/src/libraries/botan/botan.h
@@ -22,6 +22,8 @@
 #include <botan/pubkey.h>
 #include <botan/rsa.h>
 #include <botan/ui.h>
+#include <botan/pbkdf2.h>
+#include <botan/sha160.h>
 #else
 
 #include <QtGlobal>


### PR DESCRIPTION
As per #344, this is a trivial patch that adds missing headers to the list used if the qmake variable `USE_SYSTEM_BOTAN` is set. If this variable is unset, this list is ignored, so there should be no wider consequences. This is (conceivably) relevant for distribution packaging where bundled libraries are not preferred.