### PR TITLE
Sort note tree when note is renamed manually

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -7536,6 +7536,12 @@ void MainWindow::on_noteTreeWidget_itemChanged(QTreeWidgetItem *item,
 
                 // reload the directory list if note name has changed
 //                loadNoteDirectoryList();
+
+                // sort notes if note name has changed
+                if (sortAlphabetically) {
+                    ui->noteTreeWidget->sortItems(0, Qt::AscendingOrder);
+                    ui->noteTreeWidget->scrollToItem(item);
+                }
             }
         }
 


### PR DESCRIPTION
Proposed temporary fix for #450. Not required anymore when `loadNoteDirectoryList();` is called.

