### PR TITLE
Desktop file fixes

### DIFF
--- a/src/QOwnNotes.desktop
+++ b/src/QOwnNotes.desktop
@@ -8,4 +8,4 @@ Type=Application
 Terminal=false
 StartupNotify=true
 Encoding=UTF-8
-Categories=Qt;TextEditor;Todo;
+Categories=Office;Utility;TextTools;TextEditor;

--- a/src/QOwnNotes.desktop
+++ b/src/QOwnNotes.desktop
@@ -7,5 +7,4 @@ Icon=QOwnNotes
 Type=Application
 Terminal=false
 StartupNotify=true
-Encoding=UTF-8
 Categories=Office;Utility;TextTools;TextEditor;

--- a/src/QOwnNotes.desktop
+++ b/src/QOwnNotes.desktop
@@ -2,6 +2,7 @@
 Name=QOwnNotes
 Comment=Plain text notepad and todo list manager with markdown support that works together with ownCloud/Nextcloud
 Exec=QOwnNotes
+Keywords=markdown;owncloud;nextcloud;notes;
 Icon=QOwnNotes
 Type=Application
 Terminal=false


### PR DESCRIPTION
Fixes a couple of minor deviations of the `QOwnNotes.desktop` file from the desktop file spec.

 * Add `Keywords` (used by some desktop environments to filter applications as you type, eg GNOME)
 * Remove `Encoding` (obsolete [1])
 * Modify the `Categories` list (the given values didn't match the registered values [2])

[1]: https://specifications.freedesktop.org/desktop-entry-spec/1.0/apc.html
[2]: https://specifications.freedesktop.org/menu-spec/1.0/apa.html