### PR TITLE
Solve bug #689 - File found to be different just after save on windows if no UNIX newline

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2258,7 +2258,7 @@ void MainWindow::notesWereModified(const QString &str) {
 
             // fetch text of note from disk
             note.updateNoteTextFromDisk();
-            QString text2 = note.getNoteText();
+            QString text2 = Utils::Misc::transformLineFeeds(note.getNoteText());
 
             // skip dialog if texts are equal
             if (text1 == text2) {


### PR DESCRIPTION
I found the problem, it's related to CR/LF on the file when saved on WINDOWS and not on the editor (just LF). 
When you check if notes are identical (line 2264 of mainwindow.cpp), it's false of course.

On Mac, only LF is saved so no pb
I've not checked on Linux yet but should be OK too.
You have a workaround if you save using UNIX newline in Settings/General

I've added the missing part in the code to remove CR before comparison and that solve the problem ;-)