### PR TITLE
do not remove double "code blocks" (<pre><code>)

### DIFF
--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -1650,10 +1650,6 @@ QString Note::textToMarkdownHtml(QString str, QString notesPath,
                     " border-radius: 3px; color: %2; }").arg(
             codeBackgroundColor, codeForegroundColor);
 
-    // remove double code blocks
-    result.replace("<pre><code>", "<pre>")
-            .replace("</code></pre>", "</pre>");
-
     // correct the strikeout tag
     result.replace(QRegularExpression("<del>([^<]+)<\\/del>"), "<s>\\1</s>");
     bool rtl = settings.value("MainWindow/noteTextView.rtl").toBool();


### PR DESCRIPTION
I don't see why do that:
```
result.replace("<pre><code>", "<pre>").replace("</code></pre>", "</pre>");
```
It makes html export poorer (not possible to style code blocks) and also prevents assigning a language to the code block.

When entering this markdown:
```
\```python
def myfun():
    pass
\```
```
The tag is actually `<code class="language-python">` and the replacement generates broken html since it removes the closing `</code>` but not the opening one.