### PR TITLE
Add tagging support for subfolders

### DIFF
--- a/src/entities/tag.cpp
+++ b/src/entities/tag.cpp
@@ -568,17 +568,23 @@ QStringList Tag::fetchAllNames() {
 /**
  * Count the linked note file names
  */
-int Tag::countLinkedNoteFileNames(bool fromAllSubfolders) {
+int Tag::countLinkedNoteFileNames(bool fromAllSubfolders, bool recursive) {
     QSqlDatabase db = QSqlDatabase::database("note_folder");
     QSqlQuery query(db);
 
     if (fromAllSubfolders) {
     query.prepare("SELECT COUNT(note_file_name) AS cnt FROM noteTagLink "
                           "WHERE tag_id = :id");
-    } else {
+    } else if (recursive) {
         query.prepare("SELECT COUNT(note_file_name) AS cnt FROM noteTagLink "
                               "WHERE tag_id = :id AND "
-                              "note_sub_folder_path = :noteSubFolderPath");
+                              "note_sub_folder_path LIKE :noteSubFolderPath");
+        query.bindValue(":noteSubFolderPath",
+                        NoteSubFolder::activeNoteSubFolder().relativePath() + "%");
+    } else {
+        query.prepare("SELECT COUNT(note_file_name) AS cnt FROM noteTagLink "
+                      "WHERE tag_id = :id AND "
+                      "note_sub_folder_path = :noteSubFolderPath");
         query.bindValue(":noteSubFolderPath",
                         NoteSubFolder::activeNoteSubFolder().relativePath());
     }

--- a/src/entities/tag.cpp
+++ b/src/entities/tag.cpp
@@ -509,9 +509,9 @@ QStringList Tag::fetchAllLinkedNoteFileNames(bool fromAllSubfolders) {
         query.prepare("SELECT note_file_name FROM noteTagLink WHERE tag_id = :id");
     } else {
         query.prepare("SELECT note_file_name FROM noteTagLink WHERE tag_id = :id "
-                              "AND note_sub_folder_path = :noteSubFolderPath");
+                              "AND note_sub_folder_path LIKE :noteSubFolderPath");
         query.bindValue(":noteSubFolderPath",
-                    NoteSubFolder::activeNoteSubFolder().relativePath());
+                    NoteSubFolder::activeNoteSubFolder().relativePath() + "%");
     }
 
     query.bindValue(":id", this->id);

--- a/src/entities/tag.h
+++ b/src/entities/tag.h
@@ -73,7 +73,7 @@ public:
     static bool renameNoteFileNamesOfLinks(
             QString oldFileName, QString newFileName);
 
-    int countLinkedNoteFileNames(bool fromAllSubfolder);
+    int countLinkedNoteFileNames(bool fromAllSubfolder, bool recursive);
 
     static QList<Tag> fetchAllWithLinkToNoteNames(QStringList noteNameList);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6530,7 +6530,7 @@ void MainWindow::reloadTagTree() {
 
     ui->tagTreeWidget->clear();
 
-    int activeNoteSubFolderId = NoteSubFolder::activeNoteSubFolderId();
+    int activeNoteSubFolderId = _showNotesFromAllNoteSubFolders ? -1 : NoteSubFolder::activeNoteSubFolderId();
     QList<int> noteSubFolderIds;
     QList<int> noteIdList;
     int untaggedNoteCount = 0;
@@ -6547,8 +6547,7 @@ void MainWindow::reloadTagTree() {
     // get the notes from the subfolders
     Q_FOREACH(int noteSubFolderId, noteSubFolderIds) {
         // get all notes of a note sub folder
-        QList<Note> noteList = Note::fetchAllByNoteSubFolderId(
-                                                               noteSubFolderId);
+        QList<Note> noteList = Note::fetchAllByNoteSubFolderId(noteSubFolderId);
         untaggedNoteCount += Note::countAllNotTagged(noteSubFolderId);
         noteIdList << Note::noteIdListFromNoteList(noteList);
     }
@@ -6580,7 +6579,7 @@ void MainWindow::reloadTagTree() {
 
 
     // add an item to view untagged notes if there are any
-    linkCount = untaggedNoteCount;
+    linkCount = _showNotesFromAllNoteSubFolders ? Note::countAllNotTagged() : untaggedNoteCount;
 
     if (linkCount > 0) {
         toolTip = tr("show all untagged notes (%1)")


### PR DESCRIPTION
This PR allows tags to function recursively in the selected folder and subfolders!

It works well on my system, with and without the "show subfolder notes" option in the settings! :)