### PR TITLE
Reduce startup time (because QSettings from resource is slow)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,15 +3,16 @@
 #include <QApplication>
 #include <QtGui>
 #include <QSettings>
+#include <QStyleFactory>
 #include <QTranslator>
 #include <services/metricsservice.h>
 #include <widgets/logwidget.h>
 #include <services/databaseservice.h>
-#include <utils/misc.h>
-#include <QStyleFactory>
 #include "libraries/singleapplication/singleapplication.h"
 #include "version.h"
 #include "release.h"
+#include <utils/misc.h>
+#include <utils/schema.h>
 
 /**
  * Macro for loading the translations
@@ -366,6 +367,9 @@ int main(int argc, char *argv[]) {
         locale = QLocale::system().name().section('_', 0, 0);
     }
     qDebug() << __func__ << " - 'locale': " << locale;
+
+    // setup default schema settings
+    Utils::Schema::schemaSettings = new Utils::Schema::Settings();
 
 #ifndef QT_DEBUG
     QTranslator translatorRelease;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1325,9 +1325,9 @@ void MainWindow::initStyling() {
 
     // get the color name of the background color of the default text
     // highlighting item
-    QString fgColorName = Utils::Schema::getForegroundColor(
+    QString fgColorName = Utils::Schema::schemaSettings->getForegroundColor(
             MarkdownHighlighter::HighlighterState::NoState).name();
-    QString bgColorName = Utils::Schema::getBackgroundColor(
+    QString bgColorName = Utils::Schema::schemaSettings->getBackgroundColor(
             MarkdownHighlighter::HighlighterState::NoState).name();
 
     // set the foreground and background color for the note text edits

--- a/src/utils/schema.h
+++ b/src/utils/schema.h
@@ -22,38 +22,52 @@
 #include <libraries/qmarkdowntextedit/markdownhighlighter.h>
 
 namespace Utils {
+
     namespace Schema {
+        /**
+         * @brief The Settings class
+         *
+         * This exists to centralize schema settings access, reducing redundant
+         * work whenever possible.
+         */
+        class Settings {
+        public:
+            Settings();
+
+            const QStringList& defaultSchemaKeys() const;
+            const QSettings& defaultSchemaSettings() const;
+
+            QString currentSchemaKey() const;
+            bool currentSchemaIsDefault() const;
+
+            QStringList getSchemaKeys(const QString& schema) const;
+
+            QVariant getSchemaValue(const QString& key,
+                                    const QVariant& defaultValue = QVariant()) const;
+            QColor getForegroundColor(int index) const;
+            QColor getBackgroundColor(int index) const;
+
+            void setFormatStyle(MarkdownHighlighter::HighlighterState index,
+                                QTextCharFormat &format) const;
+
+            QFont getEditorTextFont() const;
+            QFont getEditorFixedFont() const;
+            QFont getEditorFont(int index) const;
+
+            void adaptFontSize(int index, QFont &font) const;
+
+        private:
+            const QSettings _defaultSchemaSettings;
+            QMap<QString, int> _defaultSchemaSubkeys;
+            QStringList _defaultSchemaKeysList;
+            QVector<QStringList> _defaultSchemaSubkeylists;
+            mutable QFont _defaultTextEditFont;
+            mutable bool _defaultFontSet;
+        };
+
+        extern Settings* schemaSettings;
         const int TextPresetIndex = -1;
 
-        QStringList defaultSchemaKeys();
-
-        QString currentSchemaKey();
-
-        bool currentSchemaIsDefault();
-
-        QSettings *getSchemaSettings();
-
-        QVariant getSchemaValue(QString key,
-                                QVariant defaultValue = QVariant());
-
-        QString textSettingsKey(QString key, int index);
-
-        QVariant getDefaultTextSchemaValue(QString key,
-                                           QVariant defaultValue = QVariant());
-
-        QColor getForegroundColor(int index);
-
-        QColor getBackgroundColor(int index);
-
-        void setFormatStyle(MarkdownHighlighter::HighlighterState index,
-                            QTextCharFormat &format);
-
-        QFont getEditorTextFont();
-
-        QFont getEditorFixedFont();
-
-        QFont getEditorFont(int index);
-
-        void adaptFontSize(int index, QFont &font);
+        QString textSettingsKey(const QString& key, int index);
     }
 }

--- a/src/widgets/qownnotesmarkdowntextedit.cpp
+++ b/src/widgets/qownnotesmarkdowntextedit.cpp
@@ -45,7 +45,7 @@ QOwnNotesMarkdownTextEdit::QOwnNotesMarkdownTextEdit(QWidget *parent)
 void QOwnNotesMarkdownTextEdit::setFormatStyle(
         MarkdownHighlighter::HighlighterState index) {
     QTextCharFormat format;
-    Utils::Schema::setFormatStyle(index, format);
+    Utils::Schema::schemaSettings->setFormatStyle(index, format);
     _highlighter->setTextFormat(index, format);
 }
 
@@ -53,7 +53,7 @@ void QOwnNotesMarkdownTextEdit::setFormatStyle(
  * Sets the highlighting styles for the text edit
  */
 void QOwnNotesMarkdownTextEdit::setStyles() {
-    QFont font = Utils::Schema::getEditorTextFont();
+    QFont font = Utils::Schema::schemaSettings->getEditorTextFont();
     setFont(font);
 
     // set the tab stop to the width of 4 spaces in the editor
@@ -365,7 +365,7 @@ void QOwnNotesMarkdownTextEdit::highlightCurrentLine()
         ensureCursorVisible();
         QTextEdit::ExtraSelection selection;
 
-        QColor lineColor = Utils::Schema::getBackgroundColor(
+        QColor lineColor = Utils::Schema::schemaSettings->getBackgroundColor(
                 MarkdownHighlighter::HighlighterState::
                 CurrentLineBackgroundColor);
 


### PR DESCRIPTION
This PR significantly reduces startup time by caching information about the default schema settings.

Having briefly tested schema changes/additions/modifications, the changes don't seem to have introduced any new bugs, although I may not have gotten to all the edge cases.

I've tried to match the existing code style, but haven't found a style guide or autoformat specification. Let me know if there's anything you want me to adjust.
