### PR TITLE
Fix the use of snap with Wayland

### DIFF
--- a/build-systems/snap/snapcraft/snapcraft.yaml
+++ b/build-systems/snap/snapcraft/snapcraft.yaml
@@ -12,6 +12,8 @@ description: |
 apps:
   qownnotes:
     command: desktop-launch ${SNAP}/usr/bin/QOwnNotes -style=Fusion --snap
+    environment:
+        DISABLE_WAYLAND: 1
     # see https://docs.snapcraft.io/reference/interfaces
     plugs:
       - x11
@@ -50,6 +52,7 @@ parts:
       - libqt5xmlpatterns5
       - libqt5printsupport5
       - libqt5declarative5
+      - qtwayland5
     stage:
       - -usr/share/pkgconfig
     after: [desktop-qt5]


### PR DESCRIPTION
Add qtwayland5 in the stage packages but disable native wayland use for now with env `DISABLE_WAYLAND=1`
Fixes #1004 
More info here:
* https://forum.snapcraft.io/t/problem-launching-qt-snaps-in-wayland/7055
* https://github.com/ubuntu/snapcraft-desktop-helpers/pull/143