### PR TITLE
Fixed failing to import notes from an existing note folder via the welcome dialog

### DIFF
--- a/src/entities/notefolder.cpp
+++ b/src/entities/notefolder.cpp
@@ -445,16 +445,18 @@ QString NoteFolder::fixRemotePath() {
  * Migrate the notesPath and the recentNoteFolders to NoteFolder objects
  */
 bool NoteFolder::migrateToNoteFolders() {
-    if (countAll() > 0) {
-        return false;
-    }
-
     QSettings settings;
-    int priority = 0;
 
     // prepend the portable data path if we are in portable mode
     QString notesPath = Utils::Misc::prependPortableDataPathIfNeeded(
-            settings.value("notesPath").toString());
+        settings.value("notesPath").toString());
+
+    if (countAll() > 0) {
+        if (currentNoteFolder().getLocalPath() == notesPath)
+            return false;
+    }
+
+    int priority = 0;
 
     // create notes path as NoteFolder
     if (!notesPath.isEmpty()) {


### PR DESCRIPTION
Steps to reproduce the bug is described in: https://github.com/pbek/QOwnNotes/issues/1140#issuecomment-461753634
Only tested in portable mode with no cloud setup.