### PR TITLE
Fixed layout settings lost if note folder is not found #1140

### DIFF
--- a/src/dialogs/welcomedialog.cpp
+++ b/src/dialogs/welcomedialog.cpp
@@ -24,7 +24,11 @@ WelcomeDialog::WelcomeDialog(QWidget *parent) :
     ui->ownCloudSettingsButton->setText(Utils::Misc::replaceOwnCloudText(
             ui->ownCloudSettingsButton->text()));
 
-    ui->finishButton->setEnabled(false);
+    // if note layout has already been set, we can finish settings in the first step
+    QSettings settings;
+    _allowFinishButton = settings.contains("workspace-initial/windowState");
+    ui->finishButton->setEnabled(_allowFinishButton);
+
     ui->backButton->setEnabled(false);
     ui->errorMessageLabel->setVisible(false);
 
@@ -176,6 +180,13 @@ void WelcomeDialog::on_backButton_clicked() {
 
 void WelcomeDialog::on_finishButton_clicked() {
     MetricsService::instance()->sendVisitIfEnabled("welcome-dialog/finished");
+    if (ui->stackedWidget->currentIndex() == WelcomePages::NoteFolderPage) {
+        if (!handleNoteFolderSetup())
+            return;
+    }
+    else {
+        ui->layoutWidget->storeSettings();
+    }
     storeNoteFolderSettings();
     done(QDialog::Accepted);
 }

--- a/src/widgets/layoutwidget.cpp
+++ b/src/widgets/layoutwidget.cpp
@@ -64,9 +64,9 @@ void LayoutWidget::updateCurrentLayout() {
     ui->layoutGraphicsView->setScene(scene);
     ui->layoutGraphicsView->fitInView(scene->sceneRect(), Qt::KeepAspectRatio);
 
-    if (!_manualSettingsStoring) {
-        storeSettings();
-    }
+    //if (!_manualSettingsStoring) {
+    //    storeSettings();
+    //}
 }
 
 void LayoutWidget::storeSettings() {

--- a/src/widgets/layoutwidget.h
+++ b/src/widgets/layoutwidget.h
@@ -22,6 +22,8 @@ public:
 
     void setManualSettingsStoring(bool enabled);
 
+    void storeSettings();
+
 private slots:
     void on_layoutComboBox_currentIndexChanged(int index);
 
@@ -39,8 +41,6 @@ private:
     void loadLayouts();
 
     void updateCurrentLayout();
-
-    void storeSettings();
 
     static QString getLayoutName(QString layoutIdentifier);
 


### PR DESCRIPTION
This PR does two things:
1. Do not always reset layout settings before showing up the welcome dialog.
2. If note folder is not found at startup while user settings are present, allow the user to only re-select the note folder and then finish the welcome dialog, so that all other settings keeps untouched.
