### PR TITLE
Implemented task list parsing in the preview #235

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -272,6 +272,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
     // look if we need update the note view every two seconds
     _noteViewUpdateTimer = new QTimer(this);
+    _noteViewUpdateTimer->setSingleShot(true);
     QObject::connect(
             _noteViewUpdateTimer,
             SIGNAL(timeout()),
@@ -2645,6 +2646,7 @@ void MainWindow::noteViewUpdateTimerSlot() {
         }
         _noteViewNeedsUpdate = false;
     }
+    _noteViewUpdateTimer->start(2000);
 }
 
 void MainWindow::storeUpdatedNotesToDisk() {
@@ -5319,7 +5321,7 @@ void MainWindow::on_noteTextView_anchorClicked(const QUrl &url) {
     qDebug() << __func__ << " - 'url': " << url;
     QString scheme = url.scheme();
 
-    if ((scheme == "note" || scheme == "noteid" || scheme == "task")) {
+    if ((scheme == "note" || scheme == "noteid" || scheme == "task" || scheme == "checkbox")) {
         openLocalUrl(url.toString());
     } else {
         ui->noteTextEdit->openUrl(url.toString());
@@ -5434,6 +5436,36 @@ void MainWindow::openLocalUrl(QString urlString) {
         }
     } else if (scheme == "task") {
         return openTodoDialog(url.host());
+    } else if (scheme == "checkbox") {
+        const auto text = ui->noteTextEdit->toPlainText();
+
+        int index = url.host().mid(1).toInt();
+        QRegExp re(R"((^|\n)\s*[-*+]\s\[([xX ]?)\])", Qt::CaseInsensitive);
+        int pos = 0;
+        while (true) {
+            pos = re.indexIn(text, pos);
+            if (pos == -1) // not found
+                return;
+            auto cursor = ui->noteTextEdit->textCursor();
+            cursor.setPosition(pos + re.matchedLength() - 1);
+            if (cursor.block().userState() == MarkdownHighlighter::HighlighterState::List) {
+                if (index == 0) {
+                    auto ch = re.cap(2);
+                    if (ch.isEmpty())
+                        cursor.insertText("x");
+                    else {
+                        cursor.movePosition(QTextCursor::PreviousCharacter, QTextCursor::KeepAnchor);
+                        cursor.insertText(ch == " " ? "x" : " ");
+                    }
+
+                    // refresh instantly
+                    _noteViewUpdateTimer->start(1);
+                    break;
+                }
+                --index;
+            }
+            pos += re.matchedLength();
+        }
     }
 }
 

--- a/src/widgets/notepreviewwidget.cpp
+++ b/src/widgets/notepreviewwidget.cpp
@@ -16,7 +16,19 @@
 #include <QDebug>
 #include <QRegExp>
 #include <QMovie>
+#include <QProxyStyle>
 
+class NoDottedOutlineForLinksStyle: public QProxyStyle {
+public:
+    int styleHint(StyleHint hint,
+                  const QStyleOption *option,
+                  const QWidget *widget,
+                  QStyleHintReturn *returnData) const Q_DECL_OVERRIDE {
+        if (hint == SH_TextControl_FocusIndicatorTextCharFormat)
+            return 0;
+        return QProxyStyle::styleHint(hint, option, widget, returnData);
+    }
+};
 
 NotePreviewWidget::NotePreviewWidget(QWidget *parent) : QTextBrowser(parent) {
     // add the hidden search widget
@@ -33,6 +45,10 @@ NotePreviewWidget::NotePreviewWidget(QWidget *parent) : QTextBrowser(parent) {
 
     installEventFilter(this);
     viewport()->installEventFilter(this);
+
+    auto proxyStyle = new NoDottedOutlineForLinksStyle;
+    proxyStyle->setParent(this);
+    setStyle(proxyStyle);
 }
 
 void NotePreviewWidget::resizeEvent(QResizeEvent* event) {
@@ -141,10 +157,38 @@ void NotePreviewWidget::animateGif(const QString &text) {
     }
 }
 
+/**
+ * @brief Replace task lists with checkboxes
+ * @return Html text with checkboxes
+ */
+QString NotePreviewWidget::handleTaskLists(const QString &text_) {
+    //TODO
+    // to ensure the clicking behavior of checkboxes,
+    // line numbers of checkboxes in the original markdown text
+    // should be provided by the markdown parser
+    auto text = text_;
+
+    const QString checkboxStart = R"(<a class="task-list-item-checkbox" href="checkbox://_)";
+    text.replace(QRegExp(R"((<li>\s*(<p>)*\s*)\[ ?\])", Qt::CaseInsensitive), "\\1" + checkboxStart + "\">&#9744;</a>");
+    text.replace(QRegExp(R"((<li>\s*(<p>)*\s*)\[[xX]\])", Qt::CaseInsensitive), "\\1" + checkboxStart + "\">&#9745;</a>");
+
+    int count = 0;
+    int pos = 0;
+    while (true) {
+        pos = text.indexOf(checkboxStart, pos);
+        if (pos == -1)
+            break;
+
+        pos += checkboxStart.length();
+        text.insert(pos, QString::number(count++));
+    }
+    return text;
+}
+
 void NotePreviewWidget::setHtml(const QString &text) {
     animateGif(text);
 
-    QTextBrowser::setHtml(text);
+    QTextBrowser::setHtml(handleTaskLists(text));
 }
 
 /**

--- a/src/widgets/notepreviewwidget.h
+++ b/src/widgets/notepreviewwidget.h
@@ -37,6 +37,7 @@ protected:
 
     QStringList extractGifUrls(const QString &text) const;
     void animateGif(const QString &text);
+    QString handleTaskLists(const QString &text);
 
 public slots:
     void hide();


### PR DESCRIPTION
Details:
1. Render checkboxes in the preview (using unicode characters).
2. Toggling the checkboxes.
3. Syntax:
   - unchecked: `- []` or `- [ ]`
   - checked: `- [x]` or `- [X]`
   -  `-` can also be `*` or `+`
4. Checkboxes in code block/comment block will be skipped. But there are still some rare and special cases not handled.
5. Some tested cases:

<pre>
```
- [ ] e
- [ ] d
* [] d
```

```
asdf
   * [x] d
- [x] e
```

- [x] a
   - [x] b
- [x] c

&#60;!--
- [ ] b
-->


```
- [ ] e
```

- [x] d
- [x] e
</pre>

6. The checkbox has class `task-list-item-checkbox`, allowing the users to customize its style.
7. How it looks like:
![task list preview](https://user-images.githubusercontent.com/2010459/52549972-e6ea9b00-2e10-11e9-918f-d32c74de6bd4.gif)