### PR TITLE
Add a setting to disable the search result count calculation

### DIFF
--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -888,6 +888,8 @@ void SettingsDialog::storePanelSettings() {
                       ui->disableSavedSearchesAutoCompletionCheckBox
                       ->isChecked());
 
+    settings.setValue("showMatches", ui->showMatchesCheckBox->isChecked());
+
     settings.setValue("noteSubfoldersPanelShowFullPath",
                       ui->noteSubfoldersPanelShowFullPathCheckBox->isChecked());
 
@@ -1346,6 +1348,9 @@ void SettingsDialog::readPanelSettings() {
 
     ui->disableSavedSearchesAutoCompletionCheckBox->setChecked(
             settings.value("disableSavedSearchesAutoCompletion").toBool());
+
+    ui->showMatchesCheckBox->setChecked(
+            settings.value("showMatches", true).toBool());
 
     if (settings.value(
             "noteSubfoldersPanelShowRootFolderName", true).toBool()) {

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -5063,10 +5063,17 @@ git config --global user.name &quot;Your name&quot;</string>
                 <string>Note search panel</string>
                </property>
                <layout class="QGridLayout" name="gridLayout_69">
-                <item row="0" column="1" colspan="2">
+                <item row="0" column="1">
                  <widget class="QCheckBox" name="disableSavedSearchesAutoCompletionCheckBox">
                   <property name="text">
                    <string>Disable auto-completion of previous searches</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QCheckBox" name="showMatchesCheckBox">
+                  <property name="text">
+                   <string>Show the number of matches in each note</string>
                   </property>
                  </widget>
                 </item>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5107,6 +5107,8 @@ void MainWindow::filterNotesBySearchLineEditText() {
         ui->noteTreeWidget->setColumnCount(2);
         int maxWidth = 0;
         QStringList searchTextTerms = Note::buildQueryStringList(searchText);
+        QSettings settings;
+        bool showMatches = settings.value("showMatches", true).toBool();
 
         while (*it) {
             QTreeWidgetItem *item = *it;
@@ -5117,7 +5119,7 @@ void MainWindow::filterNotesBySearchLineEditText() {
             item->setHidden(isHidden);
 
             // count occurrences of search terms in notes
-            if (!isHidden) {
+            if (!isHidden && showMatches) {
                 Note note = Note::fetch(noteId);
                 item->setForeground(1, QColor(Qt::gray));
                 int count = 0;


### PR DESCRIPTION
The search result count calculation (#1248) significantly slows down searching on my system (2,200 notes).  This PR adds a setting allowing the user to disable it.  (It remains enabled by default.)