### PR TITLE
Sonnet: Fix spellchecking not working due to incorrect code-block

### DIFF
--- a/src/helpers/qownnotesmarkdownhighlighter.cpp
+++ b/src/helpers/qownnotesmarkdownhighlighter.cpp
@@ -195,11 +195,11 @@ void QOwnNotesMarkdownHighlighter::highlightSpellChecking(const QString &text) {
         return;
     }
     //headline || subheadline
-    if (text.contains("====") || text.contains("----")) {
+    if (text.contains(QStringLiteral("====")) || text.contains(QStringLiteral("----")) ) {
         return;
     }
     //if it's a code block, don't spell check
-    if (text == "```") {
+    if (text.contains(QStringLiteral("```"))) {
         ++codeBlock;
         return;
     }


### PR DESCRIPTION
Spellchecking would fail if someone used ` ```[lang]` instead of just ` ``` `
#125