### PR TITLE
Call updateCurrentNote() only once when setting the note

### DIFF
--- a/src/helpers/qownnotesmarkdownhighlighter.cpp
+++ b/src/helpers/qownnotesmarkdownhighlighter.cpp
@@ -50,8 +50,12 @@ QOwnNotesMarkdownHighlighter::~QOwnNotesMarkdownHighlighter()
     delete wordTokenizer;
 }
 
-void QOwnNotesMarkdownHighlighter::updateCurrentNote() {
-    _currentNote = Note::fetch(qApp->property("currentNoteId").toInt());
+void QOwnNotesMarkdownHighlighter::updateCurrentNote(Note *_note) {
+    if (_note == nullptr) {
+        _currentNote = Note::fetch(qApp->property("currentNoteId").toInt());
+    } else {
+        _currentNote = *_note;
+    }
 }
 
 static bool hasNotEmptyText(const QString &text)
@@ -71,7 +75,7 @@ static bool hasNotEmptyText(const QString &text)
  * @param text
  */
 void QOwnNotesMarkdownHighlighter::highlightBlock(const QString &text) {
-    updateCurrentNote();
+    //updateCurrentNote();
     setCurrentBlockState(HighlighterState::NoState);
     currentBlock().setUserState(HighlighterState::NoState);
 

--- a/src/helpers/qownnotesmarkdownhighlighter.h
+++ b/src/helpers/qownnotesmarkdownhighlighter.h
@@ -48,6 +48,8 @@ public:
                                  HighlightingOption::None);
     ~QOwnNotesMarkdownHighlighter() Q_DECL_OVERRIDE;
 
+    void updateCurrentNote(Note *_note = nullptr);
+
 protected:
     void highlightBlock(const QString &text) Q_DECL_OVERRIDE;
     void highlightMarkdown(const QString& text);
@@ -61,7 +63,6 @@ protected:
 
 private:
     Note _currentNote;
-    void updateCurrentNote();
     QOwnSpellChecker *spellchecker;
 
     Sonnet::LanguageFilter *languageFilter;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3990,6 +3990,8 @@ int MainWindow::getMaxImageWidth()
 void MainWindow::setNoteTextFromNote(Note *note, bool updateNoteTextViewOnly,
                                      bool ignorePreviewVisibility) {
     if (!updateNoteTextViewOnly) {
+        dynamic_cast<QOwnNotesMarkdownHighlighter*>(
+                    ui->noteTextEdit->highlighter())->updateCurrentNote();
         ui->noteTextEdit->setText(note->getNoteText());
     }
 


### PR DESCRIPTION
Huge performance improvement especially for big notes.
#1359 