### PR TITLE
Sonnet: Disable NSSpellChecker and Enable hunspell on macOS

### DIFF
--- a/src/helpers/qownspellchecker.cpp
+++ b/src/helpers/qownspellchecker.cpp
@@ -27,9 +27,12 @@ QOwnSpellChecker::QOwnSpellChecker(QObject *parent) : QObject(parent) {
     } else {
         autoDetect = false;
     }
+
 #ifdef Q_OS_MACOS
-    QString s = spellchecker->availableLanguages().at(0);
-    spellchecker->setDefaultLanguage(s);
+    QStringList s = spellchecker->availableLanguages();
+    if (!s.contains(spellchecker->defaultLanguage())) {
+        spellchecker->setDefaultLanguage(spellchecker->availableLanguages().at(0));
+    }
 #endif
 }
 

--- a/src/libraries/sonnet/src/core/loader.cpp
+++ b/src/libraries/sonnet/src/core/loader.cpp
@@ -37,14 +37,14 @@
 
 #ifdef SONNET_STATIC
 
-#ifndef Q_OS_MACOS
-#include "../plugins/hunspell/hunspellclient.h"
-#endif
 
+#include "../plugins/hunspell/hunspellclient.h"
+
+/*
 #ifdef Q_OS_MACOS
 #include "../plugins/nsspellchecker/nsspellcheckerclient.h"
 #endif
-
+*/
 #endif
 
 namespace Sonnet {
@@ -313,12 +313,12 @@ void Loader::loadPlugins()
         qCWarning(SONNET_LOG_CORE) << "Sonnet: No speller backends available!";
     }
 #else
-#ifdef Q_OS_MACOS
-    loadPlugin(QStringLiteral("NSSpellchecker"));
-#endif //define mac
-#ifndef Q_OS_MACOS
+//#ifdef Q_OS_MACOS
+//    loadPlugin(QStringLiteral("NSSpellchecker"));
+//#endif //define mac
+//#ifndef Q_OS_MACOS
     loadPlugin(QStringLiteral("Hunspell"));
-#endif //not def mac
+//#endif //not def mac
 #endif //not static
 }
 
@@ -341,17 +341,17 @@ void Loader::loadPlugin(const QString &pluginPath)
 #else
 //hunspell only for non Mac
     Client *client = nullptr;
-#ifndef Q_OS_MACOS
+//#ifndef Q_OS_MACOS
     if (pluginPath == QLatin1String("Hunspell")) {
         client = new HunspellClient(this);
     }
-#endif //not mac
-#ifdef Q_OS_MACOS
-    if (pluginPath == QLatin1String("NSSpellchecker")) {
+//#endif //not mac
+//#ifdef Q_OS_MACOS
+//    if (pluginPath == QLatin1String("NSSpellchecker")) {
     //    else {
-        client = new NSSpellCheckerClient(this);
-    }
-#endif //mac
+//        client = new NSSpellCheckerClient(this);
+//    }
+//#endif //mac
 #endif
 
     const QStringList languages = client->languages();

--- a/src/libraries/sonnet/src/core/sonnet-core.pri
+++ b/src/libraries/sonnet/src/core/sonnet-core.pri
@@ -33,43 +33,13 @@ HEADERS += $$PWD/client_p.h \
 #           $$PWD/sonnetcore_export.h
 
 # Sonnet Plugins
-unix:!macx {
-    include($$PWD/../plugins/hunspell/hunspell.pri)
-}
+include($$PWD/../plugins/hunspell/hunspell.pri)
 
-win32 {
-    include($$PWD/../plugins/hunspell/hunspell.pri)
-}
-
-
-macx {
-    include($$PWD/../plugins/nsspellchecker/nsspellchecker.pri)
-}
+#macx {
+#    include($$PWD/../plugins/nsspellchecker/nsspellchecker.pri)
+#}
 
 
 #DEFINES += SONNETCORE_EXPORT=""
 DEFINES += INSTALLATION_PLUGIN_PATH=""
 DEFINES += SONNET_STATIC
-
-#unix:system("touch sonnetcore_export.h")
-#win32:system("type nul > sonnetcore_export.h")
-
-# Copy trigrams.map to build dir
-#defineTest(copyToDestDir) {
-#    files = $$1
-#    message
-#    for(FILE, files) {
-#        DDIR = $$OUT_PWD
-#                    FILE = $$absolute_path($$FILE)
-#        message($$FILE)
-#        # Replace slashes in paths with backslashes for Windows
-#        win32:FILE ~= s,/,\\,g
-#        win32:DDIR ~= s,/,\\,g
-
-#        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$FILE) $$quote($$DDIR) $$escape_expand(\\n\\t)
-#    }
-#    export(QMAKE_POST_LINK)
-#}
-
-#copyToDestDir(trigrams.map)
-

--- a/src/libraries/sonnet/src/plugins/hunspell/hunspellclient.cpp
+++ b/src/libraries/sonnet/src/plugins/hunspell/hunspellclient.cpp
@@ -60,7 +60,8 @@ HunspellClient::HunspellClient(QObject *parent)
       QString current = QDir::currentPath() + "/dicts";
       maybeAddPath(home);
       maybeAddPath(current);
-#else
+#endif
+#ifdef Q_OS_LINUX
     maybeAddPath(QStringLiteral("/usr/share/hunspell/"));
     maybeAddPath(QStringLiteral("/usr/share/myspell/"));
     maybeAddPath(QStringLiteral("~/.local/share/hunspell/"));
@@ -71,9 +72,11 @@ HunspellClient::HunspellClient(QObject *parent)
     QString snapDictPath = QDir::homePath() + QStringLiteral("/hunspell/");
     snapDictPath.remove(QRegularExpression(R"(snap\/qownnotes\/\w\d+\/)"));
     maybeAddPath(snapDictPath);
-
+#endif
+#ifdef Q_OS_MACOS
     //Waqar: enable this one only if we use hunspell for mac
-    //maybeAddPath(QStringLiteral("/System/Library/Spelling"));
+    maybeAddPath(QStringLiteral("/System/Library/Spelling"));
+    maybeAddPath(QStringLiteral("~/Library/Spelling"));
 #endif
 
 


### PR DESCRIPTION
Hunspell dictionaries for mac will be at:
- System/Library/Spellilng
- ~/Library/Spelling

if the directories don't exist, they need to be created.

NSSpellChecker is disabled for now, till we or someone else comes and helps us fix the performance issues with it. Perhaps create a `help wanted` issue for it?

#1359 