### PR TITLE
Allow portable mode to store dic in portable data

### DIFF
--- a/src/libraries/sonnet/src/plugins/hunspell/hunspell.pri
+++ b/src/libraries/sonnet/src/plugins/hunspell/hunspell.pri
@@ -22,4 +22,6 @@ INCLUDEPATH += ../../core
 INCLUDEPATH += hunspell/src/hunspell
 INCLUDEPATH += hunspell/src/
 
+DEFINES += HUNSPELL_DEBUG_ON
+
 

--- a/src/libraries/sonnet/src/plugins/hunspell/hunspellclient.cpp
+++ b/src/libraries/sonnet/src/plugins/hunspell/hunspellclient.cpp
@@ -32,7 +32,9 @@ using namespace Sonnet;
 HunspellClient::HunspellClient(QObject *parent)
     : Client(parent)
 {
+#ifdef HUNSPELL_DEBUG_ON
     qCDebug(SONNET_HUNSPELL) << " HunspellClient::HunspellClient";
+#endif
     QStringList dirList;
     // search QStandardPaths
     dirList.append(QStandardPaths::locateAll(
@@ -95,8 +97,10 @@ HunspellClient::~HunspellClient()
 
 SpellerPlugin *HunspellClient::createSpeller(const QString &language)
 {
+#ifdef HUNSPELL_DEBUG_ON
     qCDebug(SONNET_HUNSPELL)
     << " SpellerPlugin *HunspellClient::createSpeller(const QString &language) ;" << language;
+#endif
     HunspellDict *ad = new HunspellDict(language, m_languagePaths.value(language));
     return ad;
 }


### PR DESCRIPTION
Personal dictionary will now be stored in `portableDataPath()` when using QOwnNotes in portable mode

#1378