### PR TITLE
Fix underscore at end of word not being tokenized

### DIFF
--- a/src/helpers/qownnotesmarkdownhighlighter.cpp
+++ b/src/helpers/qownnotesmarkdownhighlighter.cpp
@@ -299,6 +299,11 @@ void QOwnNotesMarkdownHighlighter::highlightSpellChecking(const QString &text) {
         while (wordTokenizer->hasNext()) {
             QStringRef word = wordTokenizer->next();
 
+            //if the word has _ at the end, word tokenizer misses that, so cut it off
+            if (word.endsWith('_')) {
+                word.truncate(word.length()-1);
+            }
+
             //in case it's not a word, like an email or a number
             if (!wordTokenizer->isSpellcheckable()) {
                 continue;

--- a/src/helpers/qownspellchecker.cpp
+++ b/src/helpers/qownspellchecker.cpp
@@ -22,11 +22,8 @@ QOwnSpellChecker::QOwnSpellChecker(QObject *parent) : QObject(parent) {
     QSettings settings;
     active = settings.value(QStringLiteral("checkSpelling"), true).toBool();
     language = settings.value(QStringLiteral("spellCheckLanguage"), QStringLiteral("auto")).toString();
-    if (language == QStringLiteral("auto")) {
-        autoDetect = true;
-    } else {
-        autoDetect = false;
-    }
+
+    autoDetect = (language == QStringLiteral("auto"));
 
 #ifdef Q_OS_MACOS
     QStringList s = spellchecker->availableLanguages();


### PR DESCRIPTION
Underscore at the end of a word wasn't being tokenized thus causing it to be misspelled.

#1379 