### PR TITLE
Sonnet: Minor optimization for auto detect mode

### DIFF
--- a/src/helpers/qownnotesmarkdownhighlighter.cpp
+++ b/src/helpers/qownnotesmarkdownhighlighter.cpp
@@ -246,6 +246,9 @@ void QOwnNotesMarkdownHighlighter::unsetMisspelled(int start, int count) {
  * @param text
  */
 void QOwnNotesMarkdownHighlighter::highlightSpellChecking(const QString &text) {
+    if (text.length() < 2) {
+        return;
+    }
     if (!spellchecker->isValid()) {
         qDebug () << "[Sonnet]Spellchecker invalid!";
         return;

--- a/src/libraries/sonnet/src/core/guesslanguage.cpp
+++ b/src/libraries/sonnet/src/core/guesslanguage.cpp
@@ -32,6 +32,7 @@
 #include "tokenizer_p.h"
 #include "core_debug.h"
 #include "spellerplugin_p.h"
+#include <QRegularExpression>
 
 /*
 All language tags should be valid according to IETF BCP 47, as codified in RFC 4646.
@@ -585,7 +586,11 @@ GuessLanguage::~GuessLanguage()
 
 QString GuessLanguage::identify(const QString &text, const QStringList &suggestionsListIn) const
 {
-    if (text.isEmpty()) {
+    if (text.isEmpty() || text == QStringLiteral("  ")
+        || text == QStringLiteral("<!-- ") || text == QStringLiteral("-->")
+        || text == QStringLiteral("\t- ") || text.startsWith(QStringLiteral("`"))
+        || text.endsWith(QStringLiteral("`")) || text == QStringLiteral("- ")
+        || text == QStringLiteral("* ")) {
         return QString();
     }
 
@@ -625,7 +630,6 @@ QString GuessLanguage::identify(const QString &text, const QStringList &suggesti
     }
 
     qCDebug(SONNET_LOG_CORE()) << "Unable to identify string with dictionaries:" << text;
-
     // None of our methods worked, just return the best suggestion
     if (!suggestionsList.isEmpty()) {
         return suggestionsList.first();


### PR DESCRIPTION
Auto detect will now skip guessing language for
- empty spaces
- unordered list starts
- comments
- inline code starting word

If the length of the current block is less than 2, spellchecker will ignore it.

#1359 