### PR TITLE
Use std::vector::reserve for better performance

### DIFF
--- a/src/libraries/sonnet/src/plugins/hunspell/hunspell/src/hunspell/hunspell.cxx
+++ b/src/libraries/sonnet/src/plugins/hunspell/hunspell/src/hunspell/hunspell.cxx
@@ -1982,6 +1982,7 @@ int HunspellImpl::stem(char*** slst, const char* word) {
 
 int HunspellImpl::stem(char*** slst, char** desc, int n) {
   std::vector<std::string> morph;
+  morph.reserve(n);
   for (int i = 0; i < n; ++i)
     morph.push_back(desc[i]);
 
@@ -1996,6 +1997,7 @@ int HunspellImpl::generate(char*** slst, const char* word, const char* pattern) 
 
 int HunspellImpl::generate(char*** slst, const char* word, char** pl, int pln) {
   std::vector<std::string> morph;
+  morph.reserve(pln);
   for (int i = 0; i < pln; ++i)
     morph.push_back(pl[i]);
 


### PR DESCRIPTION
I have pushed the changes upstream, don't know when or if they will ever get committed. In the meantime we can just start using them