### PR TITLE
Sonnet: Remove multiple backend support

### DIFF
--- a/src/libraries/sonnet/src/core/loader_p.h
+++ b/src/libraries/sonnet/src/core/loader_p.h
@@ -95,7 +95,7 @@ public:
     /**
      * Returns names of all supported clients (e.g. ISpell, ASpell)
      */
-    QStringList clients() const;
+    QString clients() const;
 
     /**
      * Returns a list of supported languages.

--- a/src/libraries/sonnet/src/core/speller.cpp
+++ b/src/libraries/sonnet/src/core/speller.cpp
@@ -180,7 +180,7 @@ void Speller::restore()
     }
 }
 
-QStringList Speller::availableBackends() const
+QString Speller::availableBackends() const
 {
     Loader *l = Loader::openLoader();
     return l->clients();

--- a/src/libraries/sonnet/src/core/speller.h
+++ b/src/libraries/sonnet/src/core/speller.h
@@ -111,7 +111,7 @@ public: // Configuration API
     /**
      * Returns names of all supported backends (e.g. ISpell, ASpell)
      */
-    QStringList availableBackends() const;
+    QString availableBackends() const;
 
     /**
      * Returns a list of supported languages.


### PR DESCRIPTION
This commit removes multiple backend support from sonnet, since we are only using one backend i.e., 'Hunspell'. This increases spellchecker performance by a good margin and simplifies the code for our use.

#1359 