### PR TITLE
Fix autodetection for some languages

### DIFF
--- a/src/libraries/sonnet/src/core/guesslanguage.cpp
+++ b/src/libraries/sonnet/src/core/guesslanguage.cpp
@@ -755,6 +755,13 @@ QStringList GuessLanguagePrivate::identify(const QString &sample,
         guesses.append(guessFromTrigrams(sample, s_scriptLanguages.values(script)));
     }
 
+    //if guesses are empty, we just append the languages of the scripts
+    if (guesses.isEmpty() && !scripts.isEmpty()) {
+        for (const QChar::Script script : scripts) {
+            guesses.append(s_scriptLanguages.values(script));
+        }
+    }
+
     return guesses;
 }
 

--- a/src/libraries/sonnet/src/core/guesslanguage.cpp
+++ b/src/libraries/sonnet/src/core/guesslanguage.cpp
@@ -745,6 +745,12 @@ QStringList GuessLanguagePrivate::identify(const QString &sample,
     }
 
     QStringList guesses;
+    //if we have only one script, don't check trigrams
+    if (scripts.count() == 1) {
+        guesses << s_scriptLanguages.value(scripts.first());
+        return guesses;
+    }
+
     for (const QChar::Script script : scripts) {
         guesses.append(guessFromTrigrams(sample, s_scriptLanguages.values(script)));
     }


### PR DESCRIPTION
Fixes autodetection for some languages that do not have trigrams for e.g. Malayan

KDE Bug: https://bugs.kde.org/show_bug.cgi?id=176537
Changes sent upstream at: https://phabricator.kde.org/D25495