### PR TITLE
Remove broken note links check to improve performance

### DIFF
--- a/src/helpers/qownnotesmarkdownhighlighter.cpp
+++ b/src/helpers/qownnotesmarkdownhighlighter.cpp
@@ -44,7 +44,6 @@ QOwnNotesMarkdownHighlighter::QOwnNotesMarkdownHighlighter(
 
     commentHighlightingOn = true;
     codeHighlightingOn = true;
-    highlightBrokenNotesLinkOn = true;
 }
 
 QOwnNotesMarkdownHighlighter::~QOwnNotesMarkdownHighlighter()
@@ -77,14 +76,6 @@ void QOwnNotesMarkdownHighlighter::setCodeHighlighting(bool state)
         return;
     }
     codeHighlightingOn = state;
-}
-
-void QOwnNotesMarkdownHighlighter::sethighlightBrokenNotesLink(bool state)
-{
-    if (state == highlightBrokenNotesLinkOn){
-        return;
-    }
-    highlightBrokenNotesLinkOn = state;
 }
 
 /**
@@ -130,11 +121,11 @@ void QOwnNotesMarkdownHighlighter::highlightMarkdown(const QString& text) {
         highlightAdditionalRules(_highlightingRulesAfter, text);
 
         // highlight broken note links
-        if (highlightBrokenNotesLinkOn) {
-            if (text.contains(QStringLiteral("note://")) || text.contains(QStringLiteral(".md"))) {
+
+        if (text.contains(QStringLiteral("note://")) || text.contains(QStringLiteral(".md"))) {
             highlightBrokenNotesLink(text);
-            }
         }
+
     }
 
     if (commentHighlightingOn) {

--- a/src/helpers/qownnotesmarkdownhighlighter.h
+++ b/src/helpers/qownnotesmarkdownhighlighter.h
@@ -50,7 +50,6 @@ public:
     void updateCurrentNote(const Note &_note);
     void setCommentHighlighting(bool);
     void setCodeHighlighting(bool);
-    void sethighlightBrokenNotesLink(bool);
     void setSpellChecker(QOwnSpellChecker*);
 
 protected:
@@ -65,13 +64,11 @@ protected:
     void highlightSpellChecking(const QString &text);
 
 private:
+    Sonnet::WordTokenizer *wordTokenizer;
+    Sonnet::LanguageFilter *languageFilter;
+    QOwnSpellChecker *spellchecker;
+    int codeBlock;
     Note _currentNote;
     bool commentHighlightingOn;
     bool codeHighlightingOn;
-    bool highlightBrokenNotesLinkOn;
-    QOwnSpellChecker *spellchecker;
-
-    Sonnet::LanguageFilter *languageFilter;
-    Sonnet::WordTokenizer *wordTokenizer;
-    int codeBlock;
 };

--- a/src/widgets/qownnotesmarkdowntextedit.cpp
+++ b/src/widgets/qownnotesmarkdowntextedit.cpp
@@ -372,38 +372,11 @@ void QOwnNotesMarkdownTextEdit::setText(const QString &text) {
         h->setCodeHighlighting(false);
     }
 
-    //check for broken links
-    h->sethighlightBrokenNotesLink(false);
-    // check legacy note:// links
-    QRegularExpression regex(R"(note:\/\/[^\s\)>]+)");
-    QRegularExpressionMatch match = regex.match(text);
-
-    if (match.hasMatch()) {
-        h->sethighlightBrokenNotesLink(true);
-    }
-
-    // else we check for <note file.md> links
-    regex = QRegularExpression(QStringLiteral("<([^\\s`][^`]*?\\.[^`]*?[^\\s`]\\.md)>"));
-    match = regex.match(text);
-
-    if (match.hasMatch()) {
-        h->sethighlightBrokenNotesLink(true);
-    }
-
-    // else we check for [note](note file.md) links
-    regex = QRegularExpression(R"(\[[^\[\]]+\]\((\S+\.md|.+?\.md)\)\B)");
-    match = regex.match(text);
-
-    if (match.hasMatch()) {
-        h->sethighlightBrokenNotesLink(true);
-    }
-
     QMarkdownTextEdit::setText(text);
 
     //after we are done we turn everything back on
     h->setCodeHighlighting(true);
     h->setCommentHighlighting(true);
-    h->sethighlightBrokenNotesLink(true);
 }
 
 void QOwnNotesMarkdownTextEdit::resizeEvent(QResizeEvent* event) {


### PR DESCRIPTION
This check is now slowing down performance a lot so I am removing it. Note loading speed should increase a lot now, especially for notes larger than 200 lines.