### PR TITLE
Optimize folder switching when tags are enabled

### DIFF
--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -2422,7 +2422,7 @@ void SettingsDialog::on_noteFolderLocalPathButton_clicked()
  */
 void SettingsDialog::on_noteFolderActiveCheckBox_stateChanged(int arg1)
 {
-    Q_UNUSED(arg1);
+    Q_UNUSED(arg1)
 
     if (!ui->noteFolderActiveCheckBox->isChecked()) {
         const QSignalBlocker blocker(ui->noteFolderActiveCheckBox);
@@ -2430,6 +2430,7 @@ void SettingsDialog::on_noteFolderActiveCheckBox_stateChanged(int arg1)
         ui->noteFolderActiveCheckBox->setChecked(true);
     } else {
         _selectedNoteFolder.setAsCurrent();
+        MainWindow::instance()->resetBrokenTagNotesLinkFlag();
     }
 }
 

--- a/src/entities/tag.cpp
+++ b/src/entities/tag.cpp
@@ -92,7 +92,7 @@ Tag Tag::fetchByName(QString name, const bool startsWith) {
     Tag tag;
     const QString sql = QStringLiteral("SELECT * FROM tag WHERE name ") %
             QString(startsWith ? QStringLiteral("LIKE") : QStringLiteral("="))
-                    % " :name ORDER BY name";
+                    % QStringLiteral(" :name ORDER BY name");
     query.prepare(sql);
 
     if (startsWith) {
@@ -806,7 +806,7 @@ bool Tag::store() {
     query.bindValue(QStringLiteral(":name"), this->name);
     query.bindValue(QStringLiteral(":priority"), this->priority);
     query.bindValue(QStringLiteral(":parentId"), this->parentId);
-    query.bindValue(QStringLiteral(":color"), _color.isValid() ? _color.name() : QStringLiteral(""));
+    query.bindValue(QStringLiteral(":color"), _color.isValid() ? _color.name() : QString());
 
     if (!query.exec()) {
         // on error

--- a/src/entities/tag.cpp
+++ b/src/entities/tag.cpp
@@ -31,7 +31,7 @@ int Tag::getParentId() const {
     return this->parentId;
 }
 
-void Tag::setParentId(int id) {
+void Tag::setParentId(const int id) {
     this->parentId = id;
 }
 
@@ -55,11 +55,11 @@ int Tag::getPriority() const {
     return this->priority;
 }
 
-void Tag::setPriority(int value) {
+void Tag::setPriority(const int value) {
     this->priority = value;
 }
 
-Tag Tag::fetch(int id) {
+Tag Tag::fetch(const int id) {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
 
@@ -86,11 +86,11 @@ Tag Tag::fetch(int id) {
  * @param startsWith if true the tag only has to start with name
  * @return
  */
-Tag Tag::fetchByName(QString name, bool startsWith) {
+Tag Tag::fetchByName(QString name, const bool startsWith) {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
     Tag tag;
-    QString sql = QStringLiteral("SELECT * FROM tag WHERE name ") %
+    const QString sql = QStringLiteral("SELECT * FROM tag WHERE name ") %
             QString(startsWith ? QStringLiteral("LIKE") : QStringLiteral("="))
                     % " :name ORDER BY name";
     query.prepare(sql);
@@ -112,7 +112,7 @@ Tag Tag::fetchByName(QString name, bool startsWith) {
     return tag;
 }
 
-Tag Tag::fetchByName(const QString &name, int parentId) {
+Tag Tag::fetchByName(const QString &name, const int parentId) {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
     Tag tag;
@@ -256,7 +256,7 @@ QList<Tag> Tag::fetchAll() {
     return tagList;
 }
 
-QList<Tag> Tag::fetchAllByParentId(int parentId, const QString& sortBy) {
+QList<Tag> Tag::fetchAllByParentId(const int parentId, const QString& sortBy) {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
     QList<Tag> tagList;
@@ -300,7 +300,7 @@ QList<Tag> Tag::fetchAllByParentId(int parentId, const QString& sortBy) {
  * @param parentId
  * @return
  */
-QList<Tag> Tag::fetchRecursivelyByParentId(int parentId) {
+QList<Tag> Tag::fetchRecursivelyByParentId(const int parentId) {
     QList<Tag> tagList = QList<Tag>() << fetch(parentId);
 
     Q_FOREACH(const Tag &tag, fetchAllByParentId(parentId)) {
@@ -318,7 +318,7 @@ bool Tag::isTaggingShowNotesRecursively() {
     return settings.value(QStringLiteral("taggingShowNotesRecursively")).toBool();
 }
 
-int Tag::countAllParentId(int parentId) {
+int Tag::countAllParentId(const int parentId) {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
 
@@ -342,7 +342,7 @@ int Tag::countAllParentId(int parentId) {
 /**
  * Checks if the current tag has a child with tagId
  */
-bool Tag::hasChild(int tagId) const {
+bool Tag::hasChild(const int tagId) const {
     Q_FOREACH(const Tag &tag, fetchAllByParentId(id)) {
             qDebug() << __func__ << " - 'tag': " << tag;
 
@@ -573,7 +573,7 @@ QList<Tag> Tag::fetchAllWithLinkToNoteNames(const QStringList& noteNameList) {
  * Fetches all linked note file names
  */
 
-QStringList Tag::fetchAllLinkedNoteFileNames(bool fromAllSubfolders) const {
+QStringList Tag::fetchAllLinkedNoteFileNames(const bool fromAllSubfolders) const {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
     QStringList fileNameList;
@@ -639,7 +639,7 @@ QStringList Tag::fetchAllLinkedNoteFileNamesForFolder(const NoteSubFolder &noteS
 /**
  * Fetches all linked notes
  */
-QList<Note> Tag::fetchAllLinkedNotes() {
+QList<Note> Tag::fetchAllLinkedNotes() const {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
     QList<Note> noteList;
@@ -711,7 +711,7 @@ QStringList Tag::fetchAllNames() {
 /**
  * Count the linked note file names for a note folder
  */
-int Tag::countLinkedNoteFileNamesForNoteFolder(NoteSubFolder noteSubFolder, bool recursive) const {
+int Tag::countLinkedNoteFileNamesForNoteFolder(const NoteSubFolder &noteSubFolder, const bool recursive) const {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
 
@@ -747,7 +747,7 @@ int Tag::countLinkedNoteFileNamesForNoteFolder(NoteSubFolder noteSubFolder, bool
 /**
  * Count the linked note file names
  */
-int Tag::countLinkedNoteFileNames(bool fromAllSubfolders, bool recursive) const {
+int Tag::countLinkedNoteFileNames(const bool fromAllSubfolders, const bool recursive) const {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
 
@@ -1001,7 +1001,7 @@ void Tag::removeBrokenLinks() {
  * @param id
  * @return
  */
-bool Tag::removeNoteLinkById(int id) {
+bool Tag::removeNoteLinkById(const int id) {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
     query.prepare(QStringLiteral("DELETE FROM noteTagLink WHERE id = :id"));
@@ -1052,7 +1052,7 @@ bool Tag::renameNoteFileNamesOfLinks(const QString& oldFileName, const QString& 
 /**
  * Renames the note sub folder paths of note links
  */
-bool Tag::renameNoteSubFolderPathsOfLinks(QString &oldPath, QString &newPath) {
+bool Tag::renameNoteSubFolderPathsOfLinks(const QString &oldPath, const QString &newPath) {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
     query.prepare(QStringLiteral("UPDATE noteTagLink SET note_sub_folder_path = "
@@ -1092,7 +1092,7 @@ void Tag::setAsActive() {
     Tag::setAsActive(id);
 }
 
-void Tag::setAsActive(int tagId) {
+void Tag::setAsActive(const int tagId) {
     NoteFolder noteFolder = NoteFolder::currentNoteFolder();
     noteFolder.setActiveTagId(tagId);
     noteFolder.store();

--- a/src/entities/tag.h
+++ b/src/entities/tag.h
@@ -38,7 +38,7 @@ public:
 
     int getPriority() const;
 
-    void setPriority(int value);
+    void setPriority(const int value);
 
     void setAsActive();
 
@@ -48,24 +48,24 @@ public:
 
     bool removeLinkToNote(const Note &note) const;
 
-    QStringList fetchAllLinkedNoteFileNames(bool fromAllSubfolders) const;
+    QStringList fetchAllLinkedNoteFileNames(const bool fromAllSubfolders) const;
 
     QStringList fetchAllLinkedNoteFileNamesForFolder(const NoteSubFolder &noteSubFolder,
                                                      bool fromAllSubfolders) const;
 
-    QList<Note> fetchAllLinkedNotes();
+    QList<Note> fetchAllLinkedNotes() const;
 
     bool isLinkedToNote(const Note &note) const;
 
-    int countLinkedNoteFileNames(bool fromAllSubfolder, bool recursive) const;
+    int countLinkedNoteFileNames(const bool fromAllSubfolder, const bool recursive) const;
 
-    int countLinkedNoteFileNamesForNoteFolder(NoteSubFolder noteSubFolder, bool recursive) const;
+    int countLinkedNoteFileNamesForNoteFolder(const NoteSubFolder &noteSubFolder, const bool recursive) const;
 
     int getParentId() const;
 
-    void setParentId(int id);
+    void setParentId(const int id);
 
-    bool hasChild(int tagId) const;
+    bool hasChild(const int tagId) const;
 
     QColor getColor() const;
 
@@ -84,9 +84,9 @@ public:
 
     static Tag activeTag();
 
-    static Tag fetchByName(QString name, bool startsWith = false);
+    static Tag fetchByName(QString name, const bool startsWith = false);
 
-    static Tag fetchByName(const QString &name, int parentId);
+    static Tag fetchByName(const QString &name, const int parentId);
 
     static QList<Tag> fetchAllOfNote(const Note &note);
 
@@ -97,22 +97,22 @@ public:
     static bool renameNoteFileNamesOfLinks(const QString& oldFileName,
                                            const QString& newFileName);
 
-    static bool renameNoteSubFolderPathsOfLinks(QString &oldPath,
-                                                QString &newPath);
+    static bool renameNoteSubFolderPathsOfLinks(const QString &oldPath,
+                                                const QString &newPath);
 
-    static Tag fetch(int id);
+    static Tag fetch(const int id);
 
     static Tag tagFromQuery(const QSqlQuery& query);
 
     static QList<Tag> fetchAllWithLinkToNoteNames(const QStringList& noteNameList);
 
-    static QList<Tag> fetchAllByParentId(int parentId, const QString& sortBy = "created DESC");
+    static QList<Tag> fetchAllByParentId(const int parentId, const QString& sortBy = "created DESC");
 
-    static int countAllParentId(int parentId);
+    static int countAllParentId(const int parentId);
 
     static int countAllOfNote(const Note &note);
 
-    static void setAsActive(int tagId);
+    static void setAsActive(const int tagId);
 
     static void convertDirSeparator();
 
@@ -126,7 +126,7 @@ public:
 
     static QStringList searchAllNamesByName(const QString& name);
 
-    static QList<Tag> fetchRecursivelyByParentId(int parentId);
+    static QList<Tag> fetchRecursivelyByParentId(const int parentId);
 
     static bool isTaggingShowNotesRecursively();
 
@@ -141,5 +141,5 @@ protected:
 
     QString colorFieldName();
 
-    static bool removeNoteLinkById(int id);
+    static bool removeNoteLinkById(const int id);
 };

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -7294,6 +7294,7 @@ void MainWindow::on_noteFolderComboBox_currentIndexChanged(int index) {
 
     if (noteFolder.isFetched()) {
         changeNoteFolder(noteFolderId);
+        areBrokenTagNoteLinksRemoved = false;
     }
 
     // hide the noteSubFolderDockWidget menu entry if sub-folders are

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1725,6 +1725,9 @@ void MainWindow::changeNoteFolder(int noteFolderId, bool forceChange) {
     // store the note history of the old note folder
     noteHistory.storeForCurrentNoteFolder();
 
+    //recheck for broken tag note links
+    resetBrokenTagNotesLinkFlag();
+
     const NoteFolder noteFolder = NoteFolder::fetch(noteFolderId);
     if (!noteFolder.isFetched()) {
         return;
@@ -7119,6 +7122,12 @@ void MainWindow::insertHtml(QString html) {
     c.insertText(html);
 }
 
+void MainWindow::resetBrokenTagNotesLinkFlag()
+{
+    if (_brokenTagNoteLinksRemoved)
+        _brokenTagNoteLinksRemoved = false;
+}
+
 /**
  * Evaluates if file is a media file
  */
@@ -7294,7 +7303,7 @@ void MainWindow::on_noteFolderComboBox_currentIndexChanged(int index) {
 
     if (noteFolder.isFetched()) {
         changeNoteFolder(noteFolderId);
-        areBrokenTagNoteLinksRemoved = false;
+        resetBrokenTagNotesLinkFlag();
     }
 
     // hide the noteSubFolderDockWidget menu entry if sub-folders are
@@ -7331,9 +7340,9 @@ void MainWindow::reloadTagTree() {
     QSettings settings;
 
     // remove all broken note tag links
-    if (!areBrokenTagNoteLinksRemoved) {
+    if (!_brokenTagNoteLinksRemoved) {
         Tag::removeBrokenLinks();
-        areBrokenTagNoteLinksRemoved = true;
+        _brokenTagNoteLinksRemoved = true;
     }
 
     ui->tagTreeWidget->clear();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -7330,7 +7330,10 @@ void MainWindow::reloadTagTree() {
     QSettings settings;
 
     // remove all broken note tag links
-    Tag::removeBrokenLinks();
+    if (!areBrokenTagNoteLinksRemoved) {
+        Tag::removeBrokenLinks();
+        areBrokenTagNoteLinksRemoved = true;
+    }
 
     ui->tagTreeWidget->clear();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -686,6 +686,7 @@ private:
     WebSocketServerService *_webSocketServerService;
     QActionGroup *languageGroup;
     QActionGroup *spellBackendGroup;
+    bool areBrokenTagNoteLinksRemoved = false;
 
     void createSystemTrayIcon();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -172,6 +172,8 @@ public:
 
     void insertHtml(QString html);
 
+    void resetBrokenTagNotesLinkFlag();
+
 protected:
     void closeEvent(QCloseEvent *event);
 
@@ -686,7 +688,7 @@ private:
     WebSocketServerService *_webSocketServerService;
     QActionGroup *languageGroup;
     QActionGroup *spellBackendGroup;
-    bool areBrokenTagNoteLinksRemoved = false;
+    bool _brokenTagNoteLinksRemoved = false;
 
     void createSystemTrayIcon();
 


### PR DESCRIPTION
checking for broken `tagnotelinks` can take a lot of time and doing that every time we switch folders doesn't seem like a good idea. `Tagnotelinks` are automatically taken care of whenever a tag or note is removed.

This function is good in case the user deletes the notes using file manager. In that case we just run this once during startup and it remains disabled after that.

If the user still deletes notes (and QON is open), it would be taken care of in the next run of QON.

#943 