### PR TITLE
Use QRegularExpression for newer Qt versions when searching

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3902,9 +3902,13 @@ void MainWindow::searchInNoteTextEdit(QString str) {
         const QStringList queryStrings = Note::buildQueryStringList(queryStr, true);
 
         if (queryStrings.count() > 0) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+            const QRegularExpression regExp(QLatin1String("(") + queryStrings.join(
+                            QLatin1String("|")) + QLatin1String(")"), QRegularExpression::CaseInsensitiveOption);
+#else
             const QRegExp regExp(QLatin1String("(") + queryStrings.join(
                             QLatin1String("|")) + QLatin1String(")"), Qt::CaseInsensitive);
-
+#endif
             while (ui->noteTextEdit->find(regExp)) {
                 QTextEdit::ExtraSelection extra = QTextEdit::ExtraSelection();
                 extra.format.setBackground(color);

--- a/src/utils/misc.cpp
+++ b/src/utils/misc.cpp
@@ -637,8 +637,8 @@ QString Utils::Misc::parseTaskList(const QString &html, bool clickable)
     auto text = html;
 
     if (!clickable) {
-        text.replace(QRegExp(QStringLiteral(R"((<li>\s*(<p>)*\s*)\[ ?\])"), Qt::CaseInsensitive), QStringLiteral("\\1&#9744;"));
-        text.replace(QRegExp(QStringLiteral(R"((<li>\s*(<p>)*\s*)\[[xX]\])"), Qt::CaseInsensitive), QStringLiteral("\\1&#9745;"));
+        text.replace(QRegularExpression(QStringLiteral(R"((<li>\s*(<p>)*\s*)\[ ?\])"), QRegularExpression::CaseInsensitiveOption), QStringLiteral("\\1&#9744;"));
+        text.replace(QRegularExpression(QStringLiteral(R"((<li>\s*(<p>)*\s*)\[[xX]\])"), QRegularExpression::CaseInsensitiveOption), QStringLiteral("\\1&#9745;"));
         return text;
     }
 
@@ -648,8 +648,8 @@ QString Utils::Misc::parseTaskList(const QString &html, bool clickable)
     // should be provided by the markdown parser
 
     const QString checkboxStart = QStringLiteral(R"(<a class="task-list-item-checkbox" href="checkbox://_)");
-    text.replace(QRegExp(QStringLiteral(R"((<li>\s*(<p>)*\s*)\[ ?\])"), Qt::CaseInsensitive), QStringLiteral("\\1") % checkboxStart % QStringLiteral("\">&#9744;</a>"));
-    text.replace(QRegExp(QStringLiteral(R"((<li>\s*(<p>)*\s*)\[[xX]\])"), Qt::CaseInsensitive), QStringLiteral("\\1") % checkboxStart % QStringLiteral("\">&#9745;</a>"));
+    text.replace(QRegularExpression(QStringLiteral(R"((<li>\s*(<p>)*\s*)\[ ?\])"), QRegularExpression::CaseInsensitiveOption), QStringLiteral("\\1") % checkboxStart % QStringLiteral("\">&#9744;</a>"));
+    text.replace(QRegularExpression(QStringLiteral(R"((<li>\s*(<p>)*\s*)\[[xX]\])"), QRegularExpression::CaseInsensitiveOption), QStringLiteral("\\1") % checkboxStart % QStringLiteral("\">&#9745;</a>"));
 
     int count = 0;
     int pos = 0;
@@ -730,7 +730,7 @@ QString Utils::Misc::logFilePath() {
  * @return
  */
 QString Utils::Misc::transformLineFeeds(QString text) {
-    return text.replace(QRegExp(QStringLiteral(R"((\r\n)|(\n\r)|\r|\n)")), QStringLiteral("\n"));
+    return text.replace(QRegularExpression(QStringLiteral(R"((\r\n)|(\n\r)|\r|\n)")), QStringLiteral("\n"));
 }
 
 /**

--- a/src/widgets/qtexteditsearchwidget.cpp
+++ b/src/widgets/qtexteditsearchwidget.cpp
@@ -169,7 +169,7 @@ bool QTextEditSearchWidget::doReplace(bool forAll) {
     int searchMode = ui->modeComboBox->currentIndex();
     if (searchMode == RegularExpressionMode) {
         QString text = c.selectedText();
-        text.replace(QRegExp(ui->searchLineEdit->text()),
+        text.replace(QRegularExpression(ui->searchLineEdit->text()),
                              ui->replaceLineEdit->text());
         c.insertText(text);
     } else {
@@ -228,7 +228,11 @@ bool QTextEditSearchWidget::doSearch(bool searchDown, bool allowRestartAtTop) {
 
     bool found;
     if (searchMode == RegularExpressionMode) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+        found = _textEdit->find(QRegularExpression(text), options);
+#else
         found = _textEdit->find(QRegExp(text), options);
+#endif
     } else {
         found = _textEdit->find(text, options);
     }


### PR DESCRIPTION
`QRegularExpression` is supported since Qt 5.13 in `QPlaintextEdit`. Its quite a bit faster so lets use it where we can.