### PR TITLE
Optimizations for note editing

### DIFF
--- a/src/helpers/qownnotesmarkdownhighlighter.cpp
+++ b/src/helpers/qownnotesmarkdownhighlighter.cpp
@@ -108,10 +108,7 @@ void QOwnNotesMarkdownHighlighter::highlightMarkdown(const QString& text) {
     if (!text.isEmpty()) {
 
         const QString &next = currentBlock().next().text();
-        const bool isHeading =
-                text.startsWith(QLatin1String("# ")) || text.startsWith(QLatin1String("## ")) ||
-                text.startsWith(QLatin1String("### ")) || text.startsWith(QLatin1String("#### ")) ||
-                text.startsWith(QLatin1String("##### ")) || text.startsWith(QLatin1String("###### "));
+        const bool isHeading = text.at(0) == QChar('#');
         const bool isHeadWithUnderline =
                 text.startsWith(QLatin1String("===")) || text.startsWith(QLatin1String("---"));
         const bool nextHasUnderLine =

--- a/src/helpers/qownnotesmarkdownhighlighter.cpp
+++ b/src/helpers/qownnotesmarkdownhighlighter.cpp
@@ -40,7 +40,6 @@ QOwnNotesMarkdownHighlighter::QOwnNotesMarkdownHighlighter(
     spellchecker = nullptr;
     languageFilter = new Sonnet::LanguageFilter(new Sonnet::SentenceTokenizer());
     wordTokenizer = new Sonnet::WordTokenizer();
-    codeBlock = 0; // for ```
 
     commentHighlightingOn = true;
     codeHighlightingOn = true;
@@ -96,7 +95,7 @@ void QOwnNotesMarkdownHighlighter::highlightBlock(const QString &text) {
     // skip spell checking empty blocks and blocks with just "spaces"
     // the rest of the highlighting needs to be done e.g. for code blocks with empty lines
     if (spellchecker != nullptr) {
-        if (!(text.isEmpty()) && spellchecker->isActive()) {
+        if (!text.isEmpty() && spellchecker->isActive()) {
             highlightSpellChecking(text);
         }
     }
@@ -245,21 +244,13 @@ void QOwnNotesMarkdownHighlighter::highlightSpellChecking(const QString &text) {
         return;
     }
     if (!spellchecker->isValid()) {
-        qDebug () << "[Sonnet]Spellchecker invalid!";
+        qWarning () << "[Sonnet]Spellchecker invalid!";
         return;
     }
-    //headline || subheadline
-    if (text.contains(QStringLiteral("====")) || text.contains(QStringLiteral("----")) ) {
+    if (currentBlockState() == HighlighterState::HeadlineEnd ||
+        currentBlockState() == HighlighterState::CodeBlock ||
+        currentBlockState() >= HighlighterState::CodeCpp)
         return;
-    }
-    //if it's a code block, don't spell check
-    if (text.contains(QStringLiteral("```"))) {
-        ++codeBlock;
-        return;
-    }
-    if (codeBlock % 2 != 0) {
-        return;
-    }
 
 
     //use our own settings, as KDE users might face issues with Autodetection

--- a/src/helpers/qownnotesmarkdownhighlighter.h
+++ b/src/helpers/qownnotesmarkdownhighlighter.h
@@ -57,7 +57,6 @@ private:
     Sonnet::WordTokenizer *wordTokenizer;
     Sonnet::LanguageFilter *languageFilter;
     QOwnSpellChecker *spellchecker;
-    int codeBlock;
     Note _currentNote;
     bool commentHighlightingOn;
     bool codeHighlightingOn;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4020,7 +4020,8 @@ void MainWindow::setNoteTextFromNote(Note *note, bool updateNoteTextViewOnly,
  * Starts the parsing for the navigation widget
  */
 void MainWindow::startNavigationParser() {
-    ui->navigationWidget->parse(activeNoteTextEdit()->document());
+    if (ui->navigationWidget->isVisible())
+        ui->navigationWidget->parse(activeNoteTextEdit()->document());
 }
 
 /**
@@ -10884,6 +10885,8 @@ void MainWindow::on_actionSearch_text_on_the_web_triggered() {
  * Updates the line number label
  */
 void MainWindow::noteEditCursorPositionChanged() {
+    if (!_noteEditLineNumberLabel->isVisible())
+        return;
     QOwnNotesMarkdownTextEdit *textEdit = activeNoteTextEdit();
     QTextCursor cursor = textEdit->textCursor();
     QString selectedText = cursor.selectedText();


### PR DESCRIPTION
Navigation parsing and line number will now only happen if the navigation widget is active. This was causing freezes and lags while editing.