### PR TITLE
Performance improvements for navigation parsing widget

### DIFF
--- a/src/widgets/navigationwidget.cpp
+++ b/src/widgets/navigationwidget.cpp
@@ -80,11 +80,7 @@ QVector<Node> NavigationWidget::parseDocument(QTextDocument *document) {
             continue;
         }
 
-        text.remove(QRegularExpression("^#+"))
-                .remove(QRegularExpression("#+$"))
-                .remove(QRegularExpression("^\\s+"))
-                .remove(QRegularExpression("^=+$"))
-                .remove(QRegularExpression("^-+$"));
+        text.remove(QRegularExpression(QStringLiteral("^#+\\s+")));
 
         if (text.isEmpty()) {
             continue;

--- a/src/widgets/navigationwidget.cpp
+++ b/src/widgets/navigationwidget.cpp
@@ -16,6 +16,7 @@
 #include <libraries/qmarkdowntextedit/markdownhighlighter.h>
 #include "navigationwidget.h"
 #include <QRegularExpression>
+#include <QtConcurrent/QtConcurrent>
 
 
 NavigationWidget::NavigationWidget(QWidget *parent)
@@ -26,6 +27,9 @@ NavigationWidget::NavigationWidget(QWidget *parent)
             SIGNAL(currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)),
             this,
             SLOT(onCurrentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *)));
+
+    parseFutureWatcher = new QFutureWatcher<QVector<Node>>(this);
+    connect(parseFutureWatcher, SIGNAL(finished()), this, SLOT(onParseCompleted()));
 }
 
 /**
@@ -41,7 +45,7 @@ void NavigationWidget::setDocument(QTextDocument *document) {
  */
 void NavigationWidget::onCurrentItemChanged(
         QTreeWidgetItem *current, QTreeWidgetItem *previous) {
-    Q_UNUSED(previous);
+    Q_UNUSED(previous)
 
     if (current == nullptr) {
         return;
@@ -58,25 +62,17 @@ void NavigationWidget::parse(QTextDocument *document) {
     Q_UNUSED(blocker)
 
     setDocument(document);
-    clear();
-    _lastHeadingItemList.clear();
 
+    QFuture<QVector<Node>> future = QtConcurrent::run(this, &NavigationWidget::parseDocument, document);
+    this->parseFutureWatcher->setFuture(future);
+}
+
+QVector<Node> NavigationWidget::parseDocument(QTextDocument *document) {
+    QVector<Node> nodes;
     for (int i = 0; i < document->blockCount(); i++) {
         QTextBlock block = document->findBlockByNumber(i);
         int elementType = block.userState();
         QString text = block.text();
-
-        // check for unrecognized headlines, like `# Header [link](http://url)`
-//        if (text.startsWith("#") && elementType != -1) {
-//            QRegularExpressionMatch match =
-//                    QRegularExpression("^(#+)").match(text);
-//
-//            if (match.hasMatch()) {
-//                // override the element type
-//                elementType = MarkdownHighlighter::H1 +
-//                        match.captured(1).count() - 1;
-//            }
-//        }
 
         // ignore all non headline types
         if ((elementType < MarkdownHighlighter::H1) ||
@@ -94,11 +90,31 @@ void NavigationWidget::parse(QTextDocument *document) {
             continue;
         }
 
+        Node node = {text, block.position(), elementType};
+        nodes.append(node);
+    }
+    return nodes;
+}
+
+void NavigationWidget::onParseCompleted()
+{
+    QVector<Node> nodes = this->parseFutureWatcher->result();
+    if (navigationTreeNodes == nodes)
+        return;
+
+    clear();
+    _lastHeadingItemList.clear();
+
+    for (int i = 0; i < nodes.length(); ++i) {
+        Node node = nodes.at(i);
+        int elementType = node.elementType;
+        int pos = node.pos;
+        QString text = node.text;
+
         auto *item = new QTreeWidgetItem();
         item->setText(0, text);
-        item->setData(0, Qt::UserRole, block.position());
-        item->setToolTip(0, tr("headline %1").arg(
-                elementType - MarkdownHighlighter::H1 + 1));
+        item->setData(0, Qt::UserRole, pos);
+        item->setToolTip(0, tr("headline %1").arg(elementType - MarkdownHighlighter::H1 + 1));
 
         // attempt to find a suitable parent item for the element type
         QTreeWidgetItem *lastHigherItem = findSuitableParentItem(elementType);
@@ -115,7 +131,6 @@ void NavigationWidget::parse(QTextDocument *document) {
 
         _lastHeadingItemList[elementType] = item;
     }
-
     expandAll();
 }
 

--- a/src/widgets/navigationwidget.h
+++ b/src/widgets/navigationwidget.h
@@ -16,6 +16,19 @@
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 #include <QTextDocument>
+#include <QFutureWatcher>
+
+struct Node{
+    QString text;
+    int pos;
+    int elementType;
+
+    bool operator==(const Node &node) const {
+        return text == node.text &&
+                pos == node.pos &&
+                elementType == node.elementType;
+    }
+};
 
 class NavigationWidget : public QTreeWidget
 {
@@ -25,16 +38,22 @@ public:
     explicit NavigationWidget(QWidget *parent = 0);
     void parse(QTextDocument *document);
     void setDocument(QTextDocument *document);
+    QVector<Node> parseDocument(QTextDocument *document);
 
 private slots:
     void onCurrentItemChanged(
             QTreeWidgetItem *current, QTreeWidgetItem *previous);
+    void onParseCompleted();
+
 signals:
     void positionClicked(int position);
 
 private:
+
     QTextDocument *_document;
-    QMap<int, QTreeWidgetItem *> _lastHeadingItemList;
+    QHash<int, QTreeWidgetItem *> _lastHeadingItemList;
+    QFutureWatcher<QVector<Node>> *parseFutureWatcher;
+    QVector<Node> navigationTreeNodes;
 
     QTreeWidgetItem *findSuitableParentItem(int elementType);
 };


### PR DESCRIPTION
- Navigation parsing now runs concurrently, so that it doesn't block the UI.
- Navigation parsing widget only refreshes if there was some change in the document structure.
- Remove excess regexes as those don't seem necessary.