### PR TITLE
New script function noteTextEditSelectCurrentWord()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # QOwnNotes Changelog
 
+- there now is a new scripting command `script.noteTextEditSelectCurrentWord()`
+  to select the current word in the note text edit
+    - for more information please take a look at the [scripting documentation](https://docs.qownnotes.org/en/develop/scripting/README.html#select-the-current-word-in-the-note-text-edit)
+
 ## 20.1.14
 - you can now also **create sub-tasks** in the **Todo list dialog** by right-clicking
   on a todo-item (for [#1596](https://github.com/pbek/QOwnNotes/issues/1596))

--- a/doc/scripting/README.rst
+++ b/doc/scripting/README.rst
@@ -528,6 +528,27 @@ Usage in QML
 
     script.noteTextEditSelectCurrentLine();
 
+Select the current word in the note text edit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Parameters
+^^^^^^^^^^
+
+.. code:: cpp
+
+    /**
+     * Selects the current line in the note text edit
+     */
+    void ScriptingService::noteTextEditSelectCurrentWord();
+
+Usage in QML
+^^^^^^^^^^^^
+
+.. code:: javascript
+
+    script.noteTextEditSelectCurrentWord();
+
+
 Set the currently selected text in the note text edit
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/services/scriptingservice.cpp
+++ b/src/services/scriptingservice.cpp
@@ -991,6 +991,24 @@ void ScriptingService::noteTextEditSelectCurrentLine() {
 }
 
 /**
+ * Select the current word in the note text edit
+ */
+void ScriptingService::noteTextEditSelectCurrentWord() {
+    MetricsService::instance()->sendVisitIfEnabled(
+            QStringLiteral("scripting/") % QString(__func__));
+
+#ifndef INTEGRATION_TESTS
+    MainWindow *mainWindow = MainWindow::instance();
+    if (mainWindow != Q_NULLPTR) {
+        QOwnNotesMarkdownTextEdit* textEdit = mainWindow->activeNoteTextEdit();
+        QTextCursor c = textEdit->textCursor();
+        c.select(QTextCursor::WordUnderCursor);
+        textEdit->setTextCursor(c);
+    }
+#endif
+}
+
+/**
  * Sets the currently selected text in the note text edit
  *
  * @param start

--- a/src/services/scriptingservice.h
+++ b/src/services/scriptingservice.h
@@ -63,6 +63,7 @@ public:
     Q_INVOKABLE QString noteTextEditSelectedText();
     Q_INVOKABLE void noteTextEditSelectAll();
     Q_INVOKABLE void noteTextEditSelectCurrentLine();
+    Q_INVOKABLE void noteTextEditSelectCurrentWord();
     Q_INVOKABLE void noteTextEditSetSelection(int start, int end);
     Q_INVOKABLE int noteTextEditSelectionStart();
     Q_INVOKABLE int noteTextEditSelectionEnd();


### PR DESCRIPTION
Selects the current word in the editor. It can then be read with
noteTextEditSelectedText(), processed and replaced with
noteTextEditWrite("New Text").

Useful when writing weekly status reports.