### PR TITLE
Fix crash due to QString overlapping count

### DIFF
--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -2053,6 +2053,18 @@ void highlightCode(QString &str, const QString &type, int cbCount) {
     }
 }
 
+static int nonOverlapCount(const QString &str, const QChar c = '`') {
+  const auto len = str.length();
+  int count = 0;
+  for (int i = 0; i < len; ++i) {
+    if (str[i] == c && i + 2 < len && str[i + 1] == c && str[i + 2] == c) {
+      ++count;
+      i += 2;
+    }
+  }
+  return count;
+}
+
 /**
  * Converts a markdown string for a note to html
  *
@@ -2170,10 +2182,10 @@ QString Note::textToMarkdownHtml(QString str, const QString &notesPath,
     }
 
     /*CODE HIGHLIGHTING*/
-    int cbCount = str.count(QStringLiteral("```"));
+    int cbCount = nonOverlapCount(str, '`');
     if (cbCount % 2 != 0) --cbCount;
 
-    int cbTildeCount = str.count(QStringLiteral("~~~"));
+    int cbTildeCount = nonOverlapCount(str, '~');
     if (cbTildeCount % 2 != 0) --cbTildeCount;
 
     // divide by two to get actual number of code blocks


### PR DESCRIPTION
This will fix the crash,

the commit in MD4C still needs to be reverted.

The preview of the note is still incorrect so i will investigate further as to what is causing it. My guess is the CodeHighlighter and MD4C don't agree on something.

If you increase/decrease the indentation in the second para of the test note, everything becomes visible.