### PR TITLE
Simplify CMakeLists.txt. Part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ prime
 *.snap
 snap/.snapcraft/state
 src/languages/*.qm
+.vscode/
+CMakeLists.txt.user*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,6 @@
 cmake_minimum_required(VERSION 3.2.2)
 project(QOwnNotes)
 
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
-#set(CMAKE_AUTORCC ON)
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
 # include some Botan settings
 include(libraries/botan/CMakeLists.txt)
 #include sonnet core directory, required for building plugins
@@ -15,20 +9,40 @@ include_directories(libraries/sonnet/src/core)
 include(libraries/sonnet/src/plugins/hunspell/hunspell/CMakeLists.txt)
 
 
-find_package( Qt5LinguistTools )
-find_package( Qt5Core 5.3 REQUIRED )
-find_package( Qt5Widgets REQUIRED )
-find_package( Qt5Gui REQUIRED )
-find_package( Qt5Sql REQUIRED )
-find_package( Qt5Svg REQUIRED )
-find_package( Qt5Network REQUIRED )
-find_package( Qt5Xml REQUIRED )
-find_package( Qt5XmlPatterns REQUIRED )
-find_package( Qt5PrintSupport REQUIRED )
-find_package( Qt5WebSockets REQUIRED )
-find_package( Qt5Qml REQUIRED )
-find_package( Qt5X11Extras REQUIRED )
-find_package( X11 REQUIRED )
+add_executable(QOwnNotes "")
+
+set_target_properties(QOwnNotes PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+    AUTOMOC ON
+    AUTOUIC ON
+    AUTORCC ON
+)
+
+target_include_directories(QOwnNotes PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+find_package(Qt5 COMPONENTS REQUIRED
+    LinguistTools
+    Core
+    Widgets
+    Gui
+    Sql
+    Svg
+    Network
+    Xml
+    XmlPatterns
+    PrintSupport
+    WebSockets
+    Qml
+)
+if(UNIX)
+    find_package(Qt5 COMPONENTS REQUIRED X11Extras)
+    find_package( X11 REQUIRED )
+endif()
+
 find_program(CCACHE_FOUND ccache)
 
 if(CCACHE_FOUND)
@@ -37,49 +51,18 @@ if(CCACHE_FOUND)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
-qt5_wrap_ui(dialogs/ui_settingsdialog.h settingsdialog.ui)
-qt5_wrap_ui(dialogs/ui_tododialog.h tododialog.ui)
-qt5_wrap_ui(dialogs/ui_aboutdialog.h aboutdialog.ui)
-qt5_wrap_ui(widgets/ui_logwidget.h logwidget.ui)
-qt5_wrap_ui(dialogs/ui_trashdialog.h trashdialog.ui)
-qt5_wrap_ui(dialogs/ui_localtrashdialog.h localtrashdialog.ui)
-qt5_wrap_ui(dialogs/ui_linkdialog.h linkdialog.ui)
-qt5_wrap_ui(dialogs/ui_updatedialog.h updatedialog.ui)
-qt5_wrap_ui(dialogs/ui_notediffdialog.h notediffdialog.ui)
-qt5_wrap_ui(dialogs/ui_versiondialog.h versiondialog.ui)
-qt5_wrap_ui(dialogs/ui_welcomedialog.h welcomedialog.ui)
-qt5_wrap_ui(dialogs/ui_issueassistantdialog.h issueassistantdialog.ui)
-qt5_wrap_ui(dialogs/ui_tagadddialog.h tagadddialog.ui)
-qt5_wrap_ui(widgets/ui_fontcolorwidget.h fontcolorwidget.ui)
-qt5_wrap_ui(widgets/ui_evernoteimportdialog.h ui_evernoteimportdialog.ui)
-qt5_wrap_ui(widgets/ui_serverbookmarksimportdialog.h ui_serverbookmarksimportdialog.ui)
-qt5_wrap_ui(widgets/ui_layoutwidget.ui ui_layoutwidget.ui)
-qt5_wrap_ui(dialogs/ui_orphanedimagesdialog.h orphanedimagesdialog.ui)
-qt5_wrap_ui(dialogs/ui_orphanedattachmentsdialog.h orphanedattachmentsdialog.ui)
-qt5_wrap_ui(dialogs/ui_actiondialog.h actiondialog.ui)
-qt5_wrap_ui(dialogs/ui_tabledialog.h tabledialog.ui)
-qt5_wrap_ui(dialogs/ui_notedialog.h notedialog.ui)
-qt5_wrap_ui(dialogs/ui_websockettokendialog.h websockettokendialog.ui)
-qt5_wrap_ui(dialogs/ui_imagedialog.h imagedialog.ui)
-qt5_wrap_ui(libraries/qmarkdowntextedit/ui_qplaintexteditsearchwidget.h
-        libraries/qmarkdowntextedit/qplaintexteditsearchwidget.ui)
-qt5_wrap_ui(libraries/qttoolbareditor/src/toolbar_editor.hpp
-        libraries/qttoolbareditor/src/toolbar_editor.ui)
-
 set(RESOURCE_FILES
-        breeze-qownnotes.qrc
-        breeze-dark-qownnotes.qrc
-        qownnotes.qrc
-        demonotes.qrc
-        images.qrc
-        texts.qrc
-        configurations.qrc
-        libraries/qmarkdowntextedit/media.qrc
-        libraries/qdarkstyle/style.qrc
-        libraries/qkeysequencewidget/qkeysequencewidget/qkeysequencewidget.qrc
-        )
-
-qt5_add_resources(RESOURCE_ADDED ${RESOURCE_FILES})
+    breeze-qownnotes.qrc
+    breeze-dark-qownnotes.qrc
+    qownnotes.qrc
+    demonotes.qrc
+    images.qrc
+    texts.qrc
+    configurations.qrc
+    libraries/qmarkdowntextedit/media.qrc
+    libraries/qdarkstyle/style.qrc
+    libraries/qkeysequencewidget/qkeysequencewidget/qkeysequencewidget.qrc
+)
 
 set(SOURCE_FILES
     dialogs/welcomedialog.cpp
@@ -255,7 +238,7 @@ set(SOURCE_FILES
     libraries/piwiktracker/piwiktracker.h
     libraries/piwiktracker/piwiktracker.cpp
     libraries/botan/botan.h
-    libraries/botan/botan_internal.h    
+    libraries/botan/botan_internal.h
     libraries/botan/botan.cpp
     libraries/botan/botanwrapper.h
     libraries/botan/botanwrapper.cpp
@@ -291,8 +274,8 @@ set(SOURCE_FILES
     libraries/qhotkey/QHotkey/qhotkey_p.h
     libraries/qhotkey/QHotkey/qhotkey_x11.cpp
 
-	threads/scriptthread.cpp
-	threads/scriptthread.h
+    threads/scriptthread.cpp
+    threads/scriptthread.h
 
     widgets/qownnotesmarkdowntextedit.cpp
     widgets/qownnotesmarkdowntextedit.h
@@ -501,46 +484,30 @@ endif()
 install(FILES ${QON_QM_FILES}
         DESTINATION ${QT_TRANSLATIONS_DIR})
 
-add_executable(QOwnNotes ${SOURCE_FILES} ${RESOURCE_ADDED} ${QON_QM_FILES})
+target_sources(QOwnNotes PRIVATE
+    ${SOURCE_FILES}
+    ${RESOURCE_FILES}
+    ${QON_QM_FILES}
+)
 
-
-# The Qt5Widgets_INCLUDES also includes the include directories for
-# dependencies QtCore and QtGui
-include_directories(${Qt5Widgets_INCLUDES} ${Qt5Sql_INCLUDES}
-        ${Qt5Svg_INCLUDES} ${Qt5Network_INCLUDES}
-        ${Qt5Xml_INCLUDES} ${Qt5XmlPatterns_INCLUDES}
-        ${Qt5PrintSupport_INCLUDES} ${Qt5WebSockets_INCLUDES} ${Qt5Qml_INCLUDES}
-        ${Qt5X11Extras_INCLUDES})
-
-# We need add -DQT_WIDGETS_LIB when using QtWidgets in Qt 5.
-add_definitions(${Qt5Widgets_DEFINITIONS} ${Qt5Sql_DEFINITIONS}
-        ${Qt5Svg_DEFINITIONS} ${Qt5Network_DEFINITIONS}
-        ${Qt5Xml_DEFINITIONS} ${Qt5XmlPatterns_DEFINITIONS}
-        ${Qt5PrintSupport_DEFINITIONS} ${Qt5WebSockets_DEFINITIONS}
-        ${Qt5Qml_DEFINITIONS} ${Qt5X11Extras_DEFINITIONS})
-
-# Executables fail to build with Qt 5 in the default configuration
-# without -fPIE. We add that here.
-set(CMAKE_CXX_FLAGS "${Qt5Widgets_EXECUTABLE_COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS "${Qt5Sql_EXECUTABLE_COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS "${Qt5Svg_EXECUTABLE_COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS "${Qt5Network_EXECUTABLE_COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS "${Qt5Xml_EXECUTABLE_COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS "${Qt5XmlPatterns_EXECUTABLE_COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS "${Qt5PrintSupport_EXECUTABLE_COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS "${Qt5WebSockets_EXECUTABLE_COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS "${Qt5Qml_EXECUTABLE_COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS "${Qt5X11Extras_EXECUTABLE_COMPILE_FLAGS}")
-set(CMAKE_CXX_FLAGS "-std=c++0x")
-
-# The Qt5Widgets_LIBRARIES variable also includes QtGui and QtCore
-target_link_libraries(QOwnNotes ${Qt5Widgets_LIBRARIES} ${Qt5Sql_LIBRARIES}
-        ${Qt5Svg_LIBRARIES} ${Qt5Network_LIBRARIES}
-        ${Qt5Xml_LIBRARIES} ${Qt5XmlPatterns_LIBRARIES}
-        ${Qt5PrintSupport_LIBRARIES} ${Qt5WebSockets_LIBRARIES}
-        ${Qt5Qml_LIBRARIES} ${Qt5X11Extras_LIBRARIES} ${X11_LIBRARIES})
-
-#qt5_use_modules(QOwnNotes Widgets Core Gui Sql Svg Network Script Xml PrintSupport)
+# The Qt5::Widgets target will also link Qt::Gui and Qt::Core targets
+target_link_libraries(QOwnNotes PRIVATE
+    Qt5::Widgets
+    Qt5::Sql
+    Qt5::Svg
+    Qt5::Network
+    Qt5::Xml
+    Qt5::XmlPatterns
+    Qt5::PrintSupport
+    Qt5::WebSockets
+    Qt5::Qml
+)
+if(UNIX)
+    target_link_libraries(QOwnNotes PRIVATE
+        Qt5::X11Extras
+        ${X11_LIBRARIES}
+    )
+endif()
 
 # Sonnet support if we can get it to run in the future
 #find_package(KF5Sonnet)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2.2)
 project(QOwnNotes)
 
 # include some Botan settings
-include(libraries/botan/CMakeLists.txt)
+add_subdirectory(libraries/botan)
 #include sonnet core directory, required for building plugins
 include_directories(libraries/sonnet/src/core)
 #some hunspell settings for windows
@@ -23,6 +23,14 @@ target_include_directories(QOwnNotes PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
 )
+
+# Disable shared library building of libraries
+set(BUILD_SHARED_LIBS OFF)
+# Disable building tests inside QHotKey library
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+set(QHOTKEY_EXAMPLES OFF)
+add_subdirectory(libraries/qhotkey)
+
 
 find_package(Qt5 COMPONENTS REQUIRED
     LinguistTools
@@ -237,11 +245,6 @@ set(SOURCE_FILES
     services/scriptingservice.h
     libraries/piwiktracker/piwiktracker.h
     libraries/piwiktracker/piwiktracker.cpp
-    libraries/botan/botan.h
-    libraries/botan/botan_internal.h
-    libraries/botan/botan.cpp
-    libraries/botan/botanwrapper.h
-    libraries/botan/botanwrapper.cpp
     libraries/qkeysequencewidget/qkeysequencewidget/src/qkeysequencewidget_p.h
     libraries/qkeysequencewidget/qkeysequencewidget/src/qkeysequencewidget.h
     libraries/qkeysequencewidget/qkeysequencewidget/src/qkeysequencewidget.cpp
@@ -269,10 +272,6 @@ set(SOURCE_FILES
     libraries/sonnet/src/core/textbreaks_p.h
     libraries/sonnet/src/core/tokenizer.cpp
     libraries/sonnet/src/core/tokenizer_p.h
-    libraries/qhotkey/QHotkey/qhotkey.h
-    libraries/qhotkey/QHotkey/qhotkey.cpp
-    libraries/qhotkey/QHotkey/qhotkey_p.h
-    libraries/qhotkey/QHotkey/qhotkey_x11.cpp
 
     threads/scriptthread.cpp
     threads/scriptthread.h
@@ -501,11 +500,21 @@ target_link_libraries(QOwnNotes PRIVATE
     Qt5::PrintSupport
     Qt5::WebSockets
     Qt5::Qml
+    QHotkey::QHotkey
+    Botan::Botan
 )
 if(UNIX)
     target_link_libraries(QOwnNotes PRIVATE
         Qt5::X11Extras
         ${X11_LIBRARIES}
+    )
+endif()
+
+if(MINGW)
+    # Qt 5 based on MinGW does not define UNICODE for CMake
+    # only qmake automatically define UNICODE
+    target_compile_definitions(QOwnNotes PRIVATE
+        UNICODE _UNICODE
     )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -233,12 +233,6 @@ set(SOURCE_FILES
     libraries/qtcsv/src/sources/reader.cpp
     libraries/qtcsv/src/sources/filechecker.h
     libraries/qtcsv/src/sources/symbols.h
-    libraries/fakevim/fakevim/fakevimactions.h
-    libraries/fakevim/fakevim/fakevimhandler.h
-    libraries/fakevim/fakevim/fakevimactions.cpp
-    libraries/fakevim/fakevim/fakevimhandler.cpp
-    libraries/fakevim/fakevim/utils/qtcassert.h
-    libraries/fakevim/fakevim/utils/qtcassert.cpp
     services/databaseservice.cpp
     services/databaseservice.h
     services/owncloudservice.cpp
@@ -510,6 +504,7 @@ target_link_libraries(QOwnNotes PRIVATE
     Qt5::Qml
     QHotkey::QHotkey
     Botan::Botan
+    fakevim
 )
 if(UNIX)
     target_link_libraries(QOwnNotes PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,10 +26,18 @@ target_include_directories(QOwnNotes PRIVATE
 
 # Disable shared library building of libraries
 set(BUILD_SHARED_LIBS OFF)
+# QHotKey library
 # Disable building tests inside QHotKey library
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 set(QHOTKEY_EXAMPLES OFF)
 add_subdirectory(libraries/qhotkey)
+
+# FakeVim library
+set(CREATE_STATIC_LIBRARY ON)
+if(MSVC)
+    add_compile_definitions(FAKEVIM_STATIC_DEFINE QTCREATOR_UTILS_STATIC_LIB)
+endif()
+add_subdirectory(libraries/fakevim)
 
 
 find_package(Qt5 COMPONENTS REQUIRED
@@ -510,11 +518,17 @@ if(UNIX)
     )
 endif()
 
-if(MINGW)
-    # Qt 5 based on MinGW does not define UNICODE for CMake
+if(MINGW OR MSVC)
+    # Qt 5 does not define UNICODE for CMake
     # only qmake automatically define UNICODE
     target_compile_definitions(QOwnNotes PRIVATE
         UNICODE _UNICODE
+    )
+endif()
+
+if(MSVC)
+    target_compile_definitions(QOwnNotes PRIVATE
+        NOMINMAX
     )
 endif()
 

--- a/src/libraries/botan/CMakeLists.txt
+++ b/src/libraries/botan/CMakeLists.txt
@@ -1,9 +1,107 @@
 cmake_minimum_required(VERSION 3.2.2)
 project(Botan)
 
+# TODO Add conditional use system botan
+
+add_library(botan "")
+add_library(Botan::Botan ALIAS botan)
+
+target_sources(botan PRIVATE
+    botan.h
+    botan.cpp
+    botan_internal.h
+    botanwrapper.h
+    botanwrapper.cpp
+)
+
+find_package(Qt5 REQUIRED COMPONENTS Core)
+
+target_link_libraries(botan PUBLIC Qt5::Core)
+
 # add some Botan defines for Linux
-if (UNIX)
-    add_compile_definitions(BOTAN_TARGET_OS_IS_LINUX BOTAN_TARGET_OS_HAS_CLOCK_GETTIME
-            BOTAN_TARGET_OS_HAS_DLOPEN BOTAN_TARGET_OS_HAS_GMTIME_R BOTAN_TARGET_OS_HAS_POSIX_MLOCK
-            BOTAN_TARGET_OS_HAS_POSIX1 BOTAN_HAS_DYNAMICALLY_LOADED_ENGINE BOTAN_HAS_DYNAMIC_LOADER)
-endif (UNIX)
+if(UNIX)
+    # Append some definitions as PRIVATE only
+    # if they used only in cpp and botan_internal header
+    target_compile_definitions(botan PRIVATE
+        BOTAN_HAS_ENTROPY_SRC_DEV_RANDOM
+    )
+endif()
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    target_compile_definitions(botan PRIVATE
+        BOTAN_TARGET_OS_HAS_CLOCK_GETTIME
+        BOTAN_TARGET_OS_HAS_POSIX_MLOCK
+        BOTAN_TARGET_OS_HAS_POSIX1
+    )
+endif()
+if(APPLE)
+    target_compile_definitions(botan PRIVATE
+        BOTAN_TARGET_OS_HAS_POSIX1
+    )
+endif()
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_compile_definitions(botan PUBLIC BOTAN_BUILD_COMPILER_IS_GCC)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_compile_definitions(botan PUBLIC BOTAN_BUILD_COMPILER_IS_CLANG)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+    target_compile_definitions(botan PRIVATE BOTAN_BUILD_COMPILER_IS_INTEL)
+endif()
+
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(i386|i686|x86_64|AMD64)")
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        target_compile_definitions(botan PUBLIC
+            BOTAN_TARGET_CPU_IS_X86_FAMILY
+            BOTAN_TARGET_ARCH_IS_X86_32
+        )
+    elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        target_compile_definitions(botan PUBLIC
+            BOTAN_TARGET_CPU_IS_X86_FAMILY
+            BOTAN_TARGET_ARCH_IS_X86_64
+            BOTAN_TARGET_CPU_HAS_NATIVE_64BIT
+        )
+    endif()
+endif()
+
+if(WIN32)
+    target_compile_definitions(botan PRIVATE
+        BOTAN_TARGET_OS_IS_WINDOWS
+        BOTAN_TARGET_OS_HAS_WIN32
+        BOTAN_HAS_ENTROPY_SRC_WIN32
+    )
+    if(MSVC)
+        # TODO Find analog for:
+        # QMAKE_CXXFLAGS_EXCEPTIONS_ON = -EHs
+        target_compile_options(botan PUBLIC
+            "-EHs" "-wd4251" "-wd4290" "-wd4250"
+        )
+        target_compile_definitions(botan PRIVATE
+            _SCL_SECURE_NO_WARNINGS
+        )
+        target_compile_definitions(botan PUBLIC
+            BOTAN_BUILD_COMPILER_IS_MSVC
+        )
+    else()
+        target_compile_options(botan PRIVATE
+            "-fpermissive" "-finline-functions" "-Wno-long-long"
+        )
+    endif()
+endif()
+
+if(UNIX AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set_target_properties(botan PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+    )
+    target_compile_options(botan PRIVATE
+        "-fpermissive" "-finline-functions" "-Wno-long-long"
+    )
+endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "(Linux|FreeBSD)")
+    target_link_libraries(botan PRIVATE
+        rt
+    )
+    target_compile_definitions(botan PRIVATE
+        BOTAN_TARGET_OS_HAS_GETAUXVAL
+    )
+endif()

--- a/src/libraries/botan/CMakeLists.txt
+++ b/src/libraries/botan/CMakeLists.txt
@@ -77,10 +77,18 @@ if(WIN32)
         )
         target_compile_definitions(botan PRIVATE
             _SCL_SECURE_NO_WARNINGS
+            _CRT_SECURE_NO_WARNINGS
         )
         target_compile_definitions(botan PUBLIC
             BOTAN_BUILD_COMPILER_IS_MSVC
         )
+        if(NOT (MSVC_VERSION LESS 1900))
+            # For included library binary ABI does not matter
+            # so disable warning
+            target_compile_definitions(botan  PRIVATE
+                _ENABLE_EXTENDED_ALIGNED_STORAGE
+            )
+        endif()
     else()
         target_compile_options(botan PRIVATE
             "-fpermissive" "-finline-functions" "-Wno-long-long"


### PR DESCRIPTION
First of all Part 1 because of libraries are not wrapped into targets in its own `CMakeLists.txt`.

For now this pull request provide same building as before. So it will not compile under Windows OS for now.
In Linux I've tested it with Qt 5.9.0 and 5.14.2

Let's describe various modifications I've made:
1. replaced most global CMAKE variables to target based. This change is not mandatory but provide more clean global space. For `AUTOMOC`, `AUTOUIC`, `AUTORCC` is obvious.
`CMAKE_INCLUDE_CURRENT_DIR` appends current source and binary folder into include directories variable. So I've replaced that this `target_include_directories`.

2. Using multiple `find_package(Qt5<SomeModule>)` possible but incorrect.
This could be problem on user's work PCs. If user define, for example, Qt5Widgets_DIR pointing to Qt 5.7 and Qt5Network_DIR pointing to Qt 5.14 code compile but it will definitely crash.  
When you use multiple Qt5 modules it is recommended to use just Qt5 with specifying desired its components. Using `find_package(Qt5 COMPONENTS Core Widget)` provide you always same Qt 5 version for all Qt5 modules.  
Also you can use `find_package(Qt5` multiple times as I done for conditionally finding `X11Extras` module on UNIX platform

3. Using transitive dependencies of CMake.
Despite its name `target_link_libraries` not only **link** to given target but also pull from it PUBLIC include directories list, its own dependencies, compiler options, compiler definitions.  
So if library's CMake defines target you **should** use its targets not ${lib_INCLUDES}, ${lib_LIBRARIES} to minimize errors. 
Qt5 defines its targets within Qt5 namespace (using ALIAS). So for `Core` components there will `Qt5::Core` imported target. All you need is to include desired modules into `target_link_libraries` without `include_directories`, `set(CMAKE_CXX_FLAGS`, `add_definitions`.

4. Remove `qt5_wrap_ui`.
Since you define `AUTOUIC` option you no longer need to `qt5_wrap_ui` since their behavior almost identical.

5. Remove `qt5_add_resources`
Using `qt5_add_resources` and `AUTORCC` option is identical. And latter is more clean looking. 
Instead of preparing binary resources and then put them into sources of executable it is more understandable to put resources into SOURCES.
On contrast if you have large resource which you will want to dynamically load on demand then you must use `qt5_add_binary_resources`. But not in our case.

6. Split `add_executable` into calls of  empty `add_executable` and filled `target_sources`.
Such split was not possible before CMake 3.1. Usually for small projects such split not mandatory.
Putting `add_executable` with empty `""` sources list at top of file provide quick information about what targets will be in this file.  
As for `target_sources` it will add sources list into target's `SOURCES` property same as `add_executable`. But you can call it multiple times. For example, instead of conditionally filling `SOURCE_FILES` for `APPLE` platform you call `target_sources` within `if(APPLE)` block.
Also `target_sources` usable for modular defining sources for target. For example you can create `CMakeLists.txt` or '*.cmake' file within `src/widgets` folder and it will allows decrease length of main `CMakeLists.txt` file and selectively switch of some `feature` from main file without even knowing with files it consists of.  
For now I've used `target_sources` just to be able to move `add_executable` to top of file.

7. Replace generic `target_link_libraries` call with one using `PRIVATE` link type.
In case of executables it does not matter `PRIVATE` or `PUBLIC`.  
If you use form with specifying propagation type you can call `target_link_libraries` several times.
For example, in our case, I've conditionally link to `X11` related libraries only on `UNIX` platform.