### PR TITLE
Modernize CMake. Part 2. Isolate some libs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,6 @@ cmake_minimum_required(VERSION 3.2.2)
 
 project(QOwnNotes)
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+
 add_subdirectory(src)

--- a/cmake/FindBotan2.cmake
+++ b/cmake/FindBotan2.cmake
@@ -1,0 +1,48 @@
+#[[
+FindBotan
+---------
+
+Searching system installed Botan 2 library using PkgConfig
+#]]
+
+if(MSVC OR MINGW)
+    message(FATAL_ERROR "Using system Botan 2 library in Window not supported")
+endif()
+
+if(TARGET Botan2::Botan2)
+    message(STATUS "Target Botan::Botan already exists. Skipping searching")
+    return()
+endif()
+
+find_package(PkgConfig REQUIRED QUIET)
+find_package(PackageHandleStandardArgs REQUIRED QUIET)
+
+
+pkg_check_modules(Botan2
+    botan-2
+)
+
+find_library(Botan2_FullLibraryPath
+    ${Botan2_LIBRARIES}
+    PATHS ${Botan2_LIBRARY_DIRS}
+    NO_DEFAULT_PATH
+)
+
+find_package_handle_standard_args(Botan2
+    REQUIRED_VARS Botan2_LIBRARIES Botan2_INCLUDE_DIRS
+    VERSION_VAR Botan2_VERSION
+)
+message("Botan2_INCLUDE_DIRS ${Botan2_INCLUDE_DIRS}")
+
+if(Botan2_FOUND)
+    if(NOT TARGET Botan2::Botan2)
+        add_library(Botan2::Botan2
+            UNKNOWN IMPORTED GLOBAL
+        )
+        set_target_properties(Botan2::Botan2 PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES ${Botan2_INCLUDE_DIRS}
+            IMPORTED_LOCATION ${Botan2_FullLibraryPath}
+            LINK_FLAGS ${Botan2_LDFLAGS_OTHER}
+        )
+    endif()
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ if(MSVC)
     add_compile_definitions(FAKEVIM_STATIC_DEFINE QTCREATOR_UTILS_STATIC_LIB)
 endif()
 add_subdirectory(libraries/fakevim)
+add_subdirectory(libraries/diff_match_patch)
 
 
 find_package(Qt5 COMPONENTS REQUIRED
@@ -202,8 +203,6 @@ set(SOURCE_FILES
     api/tagapi.h
     api/scriptapi.cpp
     api/scriptapi.h
-    libraries/diff_match_patch/diff_match_patch.cpp
-    libraries/diff_match_patch/diff_match_patch.h
     libraries/md4c/md4c/md4c.c
     libraries/md4c/md2html/render_html.c
     libraries/md4c/md2html/entity.c
@@ -505,6 +504,7 @@ target_link_libraries(QOwnNotes PRIVATE
     QHotkey::QHotkey
     Botan::Botan
     fakevim
+    Google::DiffMatchPatch
 )
 if(UNIX)
     target_link_libraries(QOwnNotes PRIVATE

--- a/src/QOwnNotes.pro
+++ b/src/QOwnNotes.pro
@@ -83,7 +83,7 @@ TRANSLATIONS = languages/QOwnNotes_en.ts \
 CODECFORTR = UTF-8
 CONFIG += c++11
 
-INCLUDEPATH += $$PWD/libraries
+INCLUDEPATH += $$PWD/libraries $$PWD/libraries/diff_match_patch
 
 SOURCES += main.cpp\
     dialogs/attachmentdialog.cpp \

--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -25,8 +25,15 @@
 #include "api/noteapi.h"
 #include "entities/bookmark.h"
 #include "helpers/codetohtmlconverter.h"
-#include "libraries/botan/botan.h"
-#include "libraries/botan/botanwrapper.h"
+
+#ifdef USE_SYSTEM_BOTAN
+#include <botan/secmem.h>
+#include <botan/exceptn.h>
+#else
+#include <botan.h>
+#endif
+
+#include <botanwrapper.h>
 #include "libraries/md4c/md2html/render_html.h"
 #include "libraries/md4c/md4c/md4c.h"
 #include "libraries/simplecrypt/simplecrypt.h"

--- a/src/libraries/botan/CMakeLists.txt
+++ b/src/libraries/botan/CMakeLists.txt
@@ -1,15 +1,12 @@
 cmake_minimum_required(VERSION 3.2.2)
 project(Botan)
 
-# TODO Add conditional use system botan
+option(BUILD_WITH_SYSTEM_BOTAN "Build using system installed Botan 2 crypto library" OFF)
 
-add_library(botan "")
+add_library(botan STATIC "")
 add_library(Botan::Botan ALIAS botan)
 
 target_sources(botan PRIVATE
-    botan.h
-    botan.cpp
-    botan_internal.h
     botanwrapper.h
     botanwrapper.cpp
 )
@@ -17,6 +14,31 @@ target_sources(botan PRIVATE
 find_package(Qt5 REQUIRED COMPONENTS Core)
 
 target_link_libraries(botan PUBLIC Qt5::Core)
+
+target_include_directories(botan PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+
+if(BUILD_WITH_SYSTEM_BOTAN)
+    find_package(Botan2 REQUIRED)
+    if(NOT TARGET Botan2::Botan2)
+        message(FATAL_ERROR "Could not find system Botan 2 library using PkgConfig")
+    endif()
+
+    target_link_libraries(botan PUBLIC Botan2::Botan2)
+
+    target_compile_definitions(botan PUBLIC USE_SYSTEM_BOTAN)
+
+    # Instead of put next lines into else() block
+    # it is better to just return
+    return()
+endif()
+
+
+target_sources(botan PRIVATE
+    botan.h
+    botan.cpp
+    botan_internal.h
+)
+
 
 # add some Botan defines for Linux
 if(UNIX)

--- a/src/libraries/botan/botan.pri
+++ b/src/libraries/botan/botan.pri
@@ -1,4 +1,5 @@
 INCLUDEPATH *= $$PWD/..
+INCLUDEPATH += $$PWD
 HEADERS += $$PWD/botan.h \
            $$PWD/botan_internal.h
 

--- a/src/libraries/botan/botanwrapper.cpp
+++ b/src/libraries/botan/botanwrapper.cpp
@@ -1,5 +1,17 @@
 #include "botanwrapper.h"
-#include<QDebug>
+#include <QDebug>
+#ifdef USE_SYSTEM_BOTAN
+#include <botan/pipe.h>
+#include <botan/cipher_mode.h>
+#include <botan/base64.h>
+#include <botan/filters.h>
+#include <botan/pbkdf2.h>
+#include <botan/kdf.h>
+#include <botan/hmac.h>
+#include <botan/sha160.h>
+#else
+#include "botan.h"
+#endif
 
 BotanWrapper::BotanWrapper() {
     // Set the default salt size

--- a/src/libraries/botan/botanwrapper.h
+++ b/src/libraries/botan/botanwrapper.h
@@ -6,7 +6,12 @@
 //#include <fstream>
 //#include <iostream>
 //#include <string>
+#ifdef USE_SYSTEM_BOTAN
+#include <botan/types.h>
+#include <botan/secmem.h>
+#else
 #include "botan.h"
+#endif
 
 class BotanWrapper
 {

--- a/src/libraries/diff_match_patch/CMakeLists.txt
+++ b/src/libraries/diff_match_patch/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.1)
+project(DiffMatchPatchLib)
+
+add_library(diff_match_patch STATIC
+    diff_match_patch.h
+    diff_match_patch.cpp
+)
+
+add_library(Google::DiffMatchPatch ALIAS diff_match_patch)
+
+find_package(Qt5 REQUIRED COMPONENTS Core)
+
+target_include_directories(diff_match_patch PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_link_libraries(diff_match_patch PUBLIC
+    Qt5::Core
+)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -101,7 +101,7 @@
 #include "dialogs/tododialog.h"
 #include "entities/calendaritem.h"
 #include "helpers/qownnotesmarkdownhighlighter.h"
-#include "libraries/diff_match_patch/diff_match_patch.h"
+#include <diff_match_patch.h>
 #include "libraries/fakevim/fakevim/fakevimhandler.h"
 #include "libraries/sonnet/src/core/speller.h"
 #include "release.h"


### PR DESCRIPTION
I've replaced usage of **Botan** as it should: with angle brackes.

Also I've added option to use system installed Botan using CMake cache variable `BUILD_WITH_SYSTEM_BOTAN` to match `botan.pri` behavior. 
For now this option works only on Unix platforms where pkg-config exists (like in `botan.pri`).

Usage of `botan.h` replaced with individual headers in case of using system **Botan** library 