### PR TITLE
Design changes to highlighter and spellchecker class for efficiency

### DIFF
--- a/src/dialogs/issueassistantdialog.cpp
+++ b/src/dialogs/issueassistantdialog.cpp
@@ -24,12 +24,6 @@ IssueAssistantDialog::IssueAssistantDialog(QWidget *parent)
     on_issueTypeComboBox_currentIndexChanged(ProblemIssueType);
     ui->logOutputPlainTextEdit->setHighlightingEnabled(false);
 
-    // enable spellchecking
-    ui->expectedBehaviourPlainTextEdit->enableSpellChecker();
-    ui->actualBehaviourPlainTextEdit->enableSpellChecker();
-    ui->questionPlainTextEdit->enableSpellChecker();
-    ui->stepsPlainTextEdit->enableSpellChecker();
-
     QObject::connect(ui->titleLineEdit, SIGNAL(textChanged(QString)), this,
                      SLOT(allowIssuePageNextButton()));
     QObject::connect(ui->questionPlainTextEdit, SIGNAL(textChanged()), this,

--- a/src/helpers/qownnotesmarkdownhighlighter.cpp
+++ b/src/helpers/qownnotesmarkdownhighlighter.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) 2014-2020 Patrizio Bekerle -- <patrizio@bekerle.com>
  *
  * This program is free software; you can redistribute it and/or modify
@@ -23,60 +23,16 @@
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
 
-#include "libraries/sonnet/src/core/languagefilter_p.h"
-#include "libraries/sonnet/src/core/tokenizer_p.h"
 #include "qownspellchecker.h"
 
-/**
- * Markdown syntax highlighting
- *
- * markdown syntax:
- * http://daringfireball.net/projects/markdown/syntax
- *
- * @param parent
- * @return
- */
 QOwnNotesMarkdownHighlighter::QOwnNotesMarkdownHighlighter(
     QTextDocument *parent, HighlightingOptions highlightingOptions)
-    : MarkdownHighlighter(parent, highlightingOptions) {
-    spellchecker = nullptr;
-    languageFilter = nullptr;
-    wordTokenizer = nullptr;
+    : MarkdownHighlighter(parent, highlightingOptions) {}
 
-    commentHighlightingOn = true;
-    codeHighlightingOn = true;
-}
-
-QOwnNotesMarkdownHighlighter::~QOwnNotesMarkdownHighlighter() {
-    if (languageFilter != nullptr) delete languageFilter;
-    if (wordTokenizer != nullptr) delete wordTokenizer;
-    if (spellchecker) delete spellchecker;
-}
-
-void QOwnNotesMarkdownHighlighter::updateCurrentNote(const Note _note) {
-    _currentNote = std::move(_note);
-}
-
-void QOwnNotesMarkdownHighlighter::setSpellChecker(
-    QOwnSpellChecker *spellChecker) {
-    spellchecker = spellChecker;
-    languageFilter =
-        new Sonnet::LanguageFilter(new Sonnet::SentenceTokenizer());
-    wordTokenizer = new Sonnet::WordTokenizer();
-}
-
-void QOwnNotesMarkdownHighlighter::setCommentHighlighting(bool state) {
-    if (state == commentHighlightingOn) {
-        return;
+void QOwnNotesMarkdownHighlighter::updateCurrentNote(Note *note) {
+    if (note != nullptr) {
+        _currentNote = note;
     }
-    commentHighlightingOn = state;
-}
-
-void QOwnNotesMarkdownHighlighter::setCodeHighlighting(bool state) {
-    if (state == codeHighlightingOn) {
-        return;
-    }
-    codeHighlightingOn = state;
 }
 
 /**
@@ -104,10 +60,8 @@ void QOwnNotesMarkdownHighlighter::highlightBlock(const QString &text) {
     // skip spell checking empty blocks and blocks with just "spaces"
     // the rest of the highlighting needs to be done e.g. for code blocks with
     // empty lines
-    if (spellchecker != nullptr) {
-        if (!text.isEmpty() && spellchecker->isActive()) {
-            highlightSpellChecking(text);
-        }
+    if (!text.isEmpty() && QOwnSpellChecker::instance()->isActive()) {
+        highlightSpellChecking(text);
     }
 
     _highlightingFinished = true;
@@ -146,11 +100,14 @@ void QOwnNotesMarkdownHighlighter::highlightBrokenNotesLink(
                 return;
             }
 
-            const Note note = _currentNote.fetchByRelativeFileName(fileName);
+            if (_currentNote != nullptr) {
+                const Note note =
+                    _currentNote->fetchByRelativeFileName(fileName);
 
-            // if the note exists we don't need to do anything
-            if (note.isFetched()) {
-                return;
+                // if the note exists we don't need to do anything
+                if (note.isFetched()) {
+                    return;
+                }
             }
         } else {    // check [note](note file.md) links
             regex = QRegularExpression(
@@ -158,23 +115,25 @@ void QOwnNotesMarkdownHighlighter::highlightBrokenNotesLink(
             match = regex.match(text);
 
             if (match.hasMatch()) {
-                const QString fileName = Note::urlDecodeNoteUrl(match.captured(1));
+                const QString fileName =
+                    Note::urlDecodeNoteUrl(match.captured(1));
 
                 // skip urls
                 if (fileName.contains(QStringLiteral("://"))) {
                     return;
                 }
 
-                const Note note = _currentNote.fetchByRelativeFileName(fileName);
+                if (_currentNote != nullptr) {
+                    const Note note =
+                        _currentNote->fetchByRelativeFileName(fileName);
 
-                // if the note exists we don't need to do anything
-                if (note.isFetched()) {
-                    return;
+                    // if the note exists we don't need to do anything
+                    if (note.isFetched()) {
+                        return;
+                    }
                 }
-            } else {
-                // no note link was found
-                return;
             }
+            // no note link was found
         }
     }
 
@@ -182,10 +141,6 @@ void QOwnNotesMarkdownHighlighter::highlightBrokenNotesLink(
 
     setFormat(match.capturedStart(0), match.capturedLength(0), _formats[state]);
 }
-
-/*
- * Spellchecker lives here
- */
 
 void QOwnNotesMarkdownHighlighter::setMisspelled(const int start,
                                                  const int count) {
@@ -208,8 +163,8 @@ void QOwnNotesMarkdownHighlighter::highlightSpellChecking(const QString &text) {
     if (text.length() < 2) {
         return;
     }
-    if (!spellchecker->isValid()) {
-        qWarning() << "[Sonnet]Spellchecker invalid!";
+    if (!QOwnSpellChecker::instance()->isValid()) {
+        qWarning() << "Spellchecker invalid for current language!";
         return;
     }
     if (currentBlockState() == HighlighterState::HeadlineEnd ||
@@ -218,8 +173,8 @@ void QOwnNotesMarkdownHighlighter::highlightSpellChecking(const QString &text) {
         return;
 
     // use our own settings, as KDE users might face issues with Autodetection
-    const bool autodetectLanguage = spellchecker->isAutoDetectOn();
-    // spellchecker->testAttribute(Sonnet::Speller::AutoDetectLanguage) : false;
+    const bool autodetectLanguage =
+        QOwnSpellChecker::instance()->isAutoDetectOn();
     LanguageCache *languageCache = nullptr;
     if (autodetectLanguage) {
         languageCache = dynamic_cast<LanguageCache *>(currentBlockUserData());
@@ -228,6 +183,7 @@ void QOwnNotesMarkdownHighlighter::highlightSpellChecking(const QString &text) {
             setCurrentBlockUserData(languageCache);
         }
     }
+    auto languageFilter = QOwnSpellChecker::instance()->languageFilter();
     languageFilter->setBuffer(text);
     while (languageFilter->hasNext()) {
         const QStringRef sentence = languageFilter->next();
@@ -248,11 +204,13 @@ void QOwnNotesMarkdownHighlighter::highlightSpellChecking(const QString &text) {
             if (lang.isEmpty()) {
                 continue;
             }
-            spellchecker->setCurrentLanguage(lang);
+            QOwnSpellChecker::instance()->setCurrentLanguage(lang);
         }
 
+        const auto wordTokenizer =
+            QOwnSpellChecker::instance()->wordTokenizer();
         wordTokenizer->setBuffer(sentence.toString());
-        int offset = sentence.position();
+        const int offset = sentence.position();
         while (wordTokenizer->hasNext()) {
             QStringRef word = wordTokenizer->next();
 
@@ -275,9 +233,9 @@ void QOwnNotesMarkdownHighlighter::highlightSpellChecking(const QString &text) {
                 continue;
             }
             // if the word is misspelled
-            if (spellchecker->isWordMisspelled(word.toString())) {
+            if (QOwnSpellChecker::instance()->isWordMisspelled(
+                    word.toString())) {
                 setMisspelled(word.position() + offset, word.length());
-                // else we do nothing and move on to the next word
             } else {
                 // unsetMisspelled(word.position()+offset, word.length());
             }

--- a/src/helpers/qownnotesmarkdownhighlighter.h
+++ b/src/helpers/qownnotesmarkdownhighlighter.h
@@ -34,14 +34,10 @@ class QOwnNotesMarkdownHighlighter : public MarkdownHighlighter {
 
    public:
     QOwnNotesMarkdownHighlighter(
-        QTextDocument *parent = 0,
+        QTextDocument *parent = nullptr,
         HighlightingOptions highlightingOptions = HighlightingOption::None);
-    ~QOwnNotesMarkdownHighlighter() Q_DECL_OVERRIDE;
 
-    void updateCurrentNote(const Note note);
-    void setCommentHighlighting(bool);
-    void setCodeHighlighting(bool);
-    void setSpellChecker(QOwnSpellChecker *);
+    void updateCurrentNote(Note *note);
 
    protected:
     void highlightBlock(const QString &text) Q_DECL_OVERRIDE;
@@ -52,10 +48,5 @@ class QOwnNotesMarkdownHighlighter : public MarkdownHighlighter {
     void highlightSpellChecking(const QString &text);
 
    private:
-    Sonnet::WordTokenizer *wordTokenizer;
-    Sonnet::LanguageFilter *languageFilter;
-    QOwnSpellChecker *spellchecker;
-    Note _currentNote;
-    bool commentHighlightingOn;
-    bool codeHighlightingOn;
+    Note *_currentNote;
 };

--- a/src/helpers/qownspellchecker.cpp
+++ b/src/helpers/qownspellchecker.cpp
@@ -23,9 +23,9 @@ QOwnSpellChecker::QOwnSpellChecker() : _spellchecker{new Sonnet::Speller()} {
         new Sonnet::LanguageFilter(new Sonnet::SentenceTokenizer());
     _wordTokenizer = new Sonnet::WordTokenizer();
 #ifdef Q_OS_MACOS
-    QStringList s = spellchecker->availableLanguages();
-    if (!s.contains(spellchecker->defaultLanguage()) && !s.isEmpty()) {
-        spellchecker->setDefaultLanguage(s.at(0));
+    QStringList s = _spellchecker->availableLanguages();
+    if (!s.contains(_spellchecker->defaultLanguage()) && !s.isEmpty()) {
+        _spellchecker->setDefaultLanguage(s.at(0));
     }
 #endif
 }

--- a/src/helpers/qownspellchecker.h
+++ b/src/helpers/qownspellchecker.h
@@ -19,10 +19,11 @@
 #include <libraries/sonnet/src/core/speller.h>
 
 #include "LanguageCache.h"
+#include "libraries/sonnet/src/core/languagefilter_p.h"
+#include "libraries/sonnet/src/core/tokenizer_p.h"
 
 class QOwnSpellChecker {
    public:
-    QOwnSpellChecker();
     ~QOwnSpellChecker();
 
     static QOwnSpellChecker *instance();
@@ -48,7 +49,7 @@ class QOwnSpellChecker {
      * @return true if the given word is misspelled.
      */
     inline bool isWordMisspelled(const QString &word) {
-        return spellchecker->isMisspelled(word);
+        return _spellchecker->isMisspelled(word);
     }
 
     /**
@@ -126,12 +127,17 @@ class QOwnSpellChecker {
     void setAutoDetect(bool autoDetect);
     bool isAutoDetectOn() const;
 
+    Sonnet::LanguageFilter *languageFilter() const;
+
+    Sonnet::WordTokenizer *wordTokenizer() const;
+
    private:
-    static QOwnSpellChecker *qonSpellchecker;
-    Sonnet::Speller *spellchecker;
-    bool active;
-    bool autoDetect;
-    QString language;
+    QOwnSpellChecker();
+    Sonnet::Speller *_spellchecker;
+    Sonnet::LanguageFilter *_languageFilter;
+    Sonnet::WordTokenizer *_wordTokenizer;
+    bool _active;
+    bool _autoDetect;
 };
 
 #endif    // QOWNSPELLCHECKER_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -4352,10 +4352,10 @@ void MainWindow::setNoteTextFromNote(Note *note, bool updateNoteTextViewOnly,
         return;
     }
     if (!updateNoteTextViewOnly) {
-        qobject_cast<QOwnNotesMarkdownHighlighter *>(
-            ui->noteTextEdit->highlighter())
-            ->updateCurrentNote(*note);
-        ui->noteTextEdit->setText(note->getNoteText());
+      qobject_cast<QOwnNotesMarkdownHighlighter *>(
+          ui->noteTextEdit->highlighter())
+          ->updateCurrentNote(note);
+      ui->noteTextEdit->setText(note->getNoteText());
     }
 
     // update the preview text edit if the dock widget is visible

--- a/src/widgets/qownnotesmarkdowntextedit.cpp
+++ b/src/widgets/qownnotesmarkdowntextedit.cpp
@@ -49,9 +49,9 @@ QOwnNotesMarkdownTextEdit::QOwnNotesMarkdownTextEdit(QWidget *parent)
     if (_highlighter) {
         _highlighter->setHighlightingOptions(options);
 
-         // re-initialize the highlighting rules if we are using some options
+        // re-initialize the highlighting rules if we are using some options
         if (options != MarkdownHighlighter::HighlightingOption::None) {
-         _highlighter->initHighlightingRules();
+            _highlighter->initHighlightingRules();
         }
     }
 }
@@ -388,51 +388,12 @@ QMargins QOwnNotesMarkdownTextEdit::viewportMargins() {
 #endif
 }
 
-void QOwnNotesMarkdownTextEdit::enableSpellChecker(
-    QOwnNotesMarkdownHighlighter *h) {
-    if (!h) {
-        h = qobject_cast<QOwnNotesMarkdownHighlighter *>(_highlighter);
-    }
-
-    h->setSpellChecker(QOwnSpellChecker::instance());
-}
-
 void QOwnNotesMarkdownTextEdit::setText(const QString &text) {
-    QSettings settings;
-    bool highlightingEnabled =
-        settings.value(QStringLiteral("markdownHighlightingEnabled"), true)
-            .toBool();
-    if (!highlightingEnabled) {
-        QMarkdownTextEdit::setText(text);
-        return;
-    }
-    QOwnNotesMarkdownHighlighter *h =
-        qobject_cast<QOwnNotesMarkdownHighlighter *>(_highlighter);
-
-    if (_spellCheckerEnabled) {
-        enableSpellChecker(h);
-    }
-
-    // check for comment block
-    if (!text.contains(QStringLiteral("<!--"))) {
-        h->setCommentHighlighting(false);
-    }
-
-    // check for code blocks
-    if (!(text.contains(QStringLiteral("```")) ||
-          text.contains(QStringLiteral("~~~")))) {
-        h->setCodeHighlighting(false);
-    }
-
     QMarkdownTextEdit::setText(text);
-
-    // after we are done we turn everything back on
-    h->setCodeHighlighting(true);
-    h->setCommentHighlighting(true);
 }
 
 void QOwnNotesMarkdownTextEdit::setSpellcheckingEnabled(bool enabled) {
-    _spellCheckerEnabled = enabled;
+    QOwnSpellChecker::instance()->setActive(enabled);
 }
 
 void QOwnNotesMarkdownTextEdit::resizeEvent(QResizeEvent *event) {

--- a/src/widgets/qownnotesmarkdowntextedit.h
+++ b/src/widgets/qownnotesmarkdowntextedit.h
@@ -31,8 +31,7 @@ class QOwnNotesMarkdownTextEdit : public QMarkdownTextEdit {
     void updateSettings();
     QMargins viewportMargins();
     void setText(const QString &text);
-    void setSpellcheckingEnabled(bool enabled);
-    void enableSpellChecker(QOwnNotesMarkdownHighlighter *h = nullptr);
+    static void setSpellcheckingEnabled(bool enabled);
 
    protected:
     // we must not override _highlighter or Windows will create a
@@ -47,7 +46,6 @@ class QOwnNotesMarkdownTextEdit : public QMarkdownTextEdit {
 
    private:
     MainWindow *mainWindow;
-    bool _spellCheckerEnabled = true;
 
     void setFormatStyle(MarkdownHighlighter::HighlighterState index);
 


### PR DESCRIPTION
- Removed some dead code like `setCommentHighlighting`
- Use the spellchecker object directly, no need to make it member variable when we have it available globally
- Removed redundant initialization of spellchecker properties from it's constructor. It now gets initialized from the `QOwnNotesMarkdownEditor::updateSettings()`
- `wordTokenizer` and `languageFilter` are now a part of spellchecker. This gives us one point to control everything related to spellchecking.
- `_currentNote` object is now a ptr.
- The overall size of `QOwnNotesMarkdownHighlighter` class is now 64 bytes from 196 previously. It can be reduced further by making some changes to the base class