### PR TITLE
Fix null pointer dereference

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10446,7 +10446,7 @@ void MainWindow::openNotesContextMenu(const QPoint globalPos,
  */
 void MainWindow::on_noteTreeWidget_itemChanged(QTreeWidgetItem *item,
                                                int column) {
-    if (item == nullptr || !Note::allowDifferentFileName()) {
+    if (item == nullptr) {
         return;
     }
     // handle note subfolder renaming in a note tree
@@ -10455,7 +10455,9 @@ void MainWindow::on_noteTreeWidget_itemChanged(QTreeWidgetItem *item,
 
         return;
     }
-
+    if (!Note::allowDifferentFileName()) {
+        return;
+    }
     const int noteId = item->data(0, Qt::UserRole).toInt();
     Note note = Note::fetch(noteId);
     if (note.isFetched()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10456,11 +10456,11 @@ void MainWindow::on_noteTreeWidget_itemChanged(QTreeWidgetItem *item,
 
         return;
     }
-    
+
     if (!Note::allowDifferentFileName()) {
         return;
     }
-    
+
     const int noteId = item->data(0, Qt::UserRole).toInt();
     Note note = Note::fetch(noteId);
     if (note.isFetched()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10449,15 +10449,18 @@ void MainWindow::on_noteTreeWidget_itemChanged(QTreeWidgetItem *item,
     if (item == nullptr) {
         return;
     }
+    
     // handle note subfolder renaming in a note tree
     if (item->data(0, Qt::UserRole + 1) == FolderType) {
         on_noteSubFolderTreeWidget_itemChanged(item, column);
 
         return;
     }
+    
     if (!Note::allowDifferentFileName()) {
         return;
     }
+    
     const int noteId = item->data(0, Qt::UserRole).toInt();
     Note note = Note::fetch(noteId);
     if (note.isFetched()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10446,14 +10446,13 @@ void MainWindow::openNotesContextMenu(const QPoint globalPos,
  */
 void MainWindow::on_noteTreeWidget_itemChanged(QTreeWidgetItem *item,
                                                int column) {
+    if (item == nullptr || !Note::allowDifferentFileName()) {
+        return;
+    }
     // handle note subfolder renaming in a note tree
     if (item->data(0, Qt::UserRole + 1) == FolderType) {
         on_noteSubFolderTreeWidget_itemChanged(item, column);
 
-        return;
-    }
-
-    if (item == nullptr || !Note::allowDifferentFileName()) {
         return;
     }
 


### PR DESCRIPTION
I am not sure if checking `!Note::allowDifferentFileName()` before `item->data(0, Qt::UserRole + 1) == FolderType` is a good idea, but it seems to be alright