### PR TITLE
Move away from QList to QVector for Tags 

### DIFF
--- a/src/api/noteapi.cpp
+++ b/src/api/noteapi.cpp
@@ -8,11 +8,11 @@
 
 #include "tagapi.h"
 
-NoteApi* NoteApi::fetch(int _id) {
-    _note = Note::fetch(_id);
+NoteApi* NoteApi::fetch(int id) {
+    _note = Note::fetch(id);
 
     if (_note.isFetched()) {
-        this->_id = _note.getId();
+        _id = _note.getId();
         _name = _note.getName();
         _fileName = _note.getFileName();
         _noteText = _note.getNoteText();
@@ -45,8 +45,8 @@ QQmlListProperty<TagApi> NoteApi::tags() {
     _tags.clear();
 
     Note note = Note::fetch(_id);
-    QList<Tag> tags = Tag::fetchAllOfNote(note);
-    QListIterator<Tag> itr(tags);
+    QVector<Tag> tags = Tag::fetchAllOfNote(note);
+    QVectorIterator<Tag> itr(tags);
     while (itr.hasNext()) {
         Tag tag = itr.next();
 
@@ -54,8 +54,11 @@ QQmlListProperty<TagApi> NoteApi::tags() {
         tagApi->fetch(tag.getId());
         _tags.append(tagApi);
     }
-
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
     return {this, _tags};
+#else
+    return {this, &_tags};
+#endif
 }
 
 /**
@@ -64,8 +67,8 @@ QQmlListProperty<TagApi> NoteApi::tags() {
 QStringList NoteApi::tagNames() const {
     QStringList tagNameList;
     Note note = Note::fetch(_id);
-    QList<Tag> tags = Tag::fetchAllOfNote(note);
-    QListIterator<Tag> itr(tags);
+    QVector<Tag> tags = Tag::fetchAllOfNote(note);
+    QVectorIterator<Tag> itr(tags);
     while (itr.hasNext()) {
         Tag tag = itr.next();
         tagNameList.append(tag.getName());
@@ -154,15 +157,18 @@ bool NoteApi::allowDifferentFileName() {
  * @return
  */
 QQmlListProperty<NoteApi> NoteApi::fetchAll(int limit, int offset) {
-    QVector<int> noteIds = Note::fetchAllIds(limit, offset);
+    const QVector<int> noteIds = Note::fetchAllIds(limit, offset);
     QList<NoteApi*> notes;
 
-    Q_FOREACH (int noteId, noteIds) {
+    for (int noteId : noteIds) {
         NoteApi* note = NoteApi::fetch(noteId);
         notes.append(note);
     }
-
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
     return {this, notes};
+#else
+    return {this, &notes};
+#endif
 }
 
 /**

--- a/src/entities/tag.cpp
+++ b/src/entities/tag.cpp
@@ -404,7 +404,11 @@ QVector<Tag> Tag::fetchAllOfNotes(const QVector<Note> &notes) {
 
     //get all tags for the notes list
     for (const Note &note : notes) {
+#if (QT_VERSION < QT_VERSION_CHECK(5, 5, 0))
+        notesTagList += Tag::fetchAllOfNote(note);
+#else
         notesTagList.append(Tag::fetchAllOfNote(note));
+#endif
     }
     //sort
     std::sort (notesTagList.begin(), notesTagList.end());

--- a/src/entities/tag.h
+++ b/src/entities/tag.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <QColor>
-#include <QList>
+#include <QVector>
 #include <QSqlQuery>
 
 class Note;
@@ -57,7 +57,7 @@ class Tag {
         const NoteSubFolder &noteSubFolder, bool fromAllSubfolders,
         const bool recursive = true) const;
 
-    QList<Note> fetchAllLinkedNotes() const;
+    QVector<Note> fetchAllLinkedNotes() const;
 
     bool isLinkedToNote(const Note &note) const;
 
@@ -82,7 +82,7 @@ class Tag {
      * Public static functions
      */
 
-    static QList<Tag> fetchAll();
+    static QVector<Tag> fetchAll();
 
     static int countAll();
 
@@ -94,7 +94,7 @@ class Tag {
 
     static Tag fetchByName(const QString &name, const int parentId);
 
-    static QList<Tag> fetchAllOfNote(const Note &note);
+    static QVector<Tag> fetchAllOfNote(const Note &note);
 
     static QStringList fetchAllNames();
 
@@ -111,10 +111,10 @@ class Tag {
 
     static Tag tagFromQuery(const QSqlQuery &query);
 
-    static QList<Tag> fetchAllWithLinkToNoteNames(
+    static QVector<Tag> fetchAllWithLinkToNoteNames(
         const QStringList &noteNameList);
 
-    static QList<Tag> fetchAllByParentId(
+    static QVector<Tag> fetchAllByParentId(
         const int parentId,
         const QString &sortBy = QStringLiteral("created DESC"));
 
@@ -138,13 +138,13 @@ class Tag {
 
     static QStringList searchAllNamesByName(const QString &name);
 
-    static QList<Tag> fetchRecursivelyByParentId(const int parentId);
+    static QVector<Tag> fetchRecursivelyByParentId(const int parentId);
 
     QStringList getParentTagNames();
 
     static bool isTaggingShowNotesRecursively();
 
-    static QList<Tag> fetchAllOfNotes(const QVector<Note> &notes);
+    static QVector<Tag> fetchAllOfNotes(const QVector<Note> &notes);
 
     static bool mergeFromDatabase(QSqlDatabase &db);
 

--- a/src/services/websocketserverservice.cpp
+++ b/src/services/websocketserverservice.cpp
@@ -325,11 +325,11 @@ QString WebSocketServerService::getBookmarksJsonText() const {
     }
 
     Tag tag = Tag::fetchByName(getBookmarksTag());
-    QList<Note> noteList = tag.fetchAllLinkedNotes();
+    const QVector<Note> noteList = tag.fetchAllLinkedNotes();
     QVector<Bookmark> bookmarks;
 
     // get all bookmark links from notes tagged with the bookmarks tag
-    Q_FOREACH (Note note, noteList) {
+    for (const Note &note : noteList) {
         QVector<Bookmark> noteBookmarks = note.getParsedBookmarks();
 
         // merge bookmark lists


### PR DESCRIPTION
- Move away from QList to QVector for Tags  for better performance
- Fix deprecation warnings in NoteApi for `QQMLListProperty`
- Tag tree reloading should be somewhat faster now #943