### PR TITLE
Lots of tiny improvements and optimizations

### DIFF
--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -161,8 +161,6 @@ Note Note::fetch(int id) {
     const QSqlDatabase db = QSqlDatabase::database(QStringLiteral("memory"));
     QSqlQuery query(db);
 
-    Note note;
-
     query.prepare(QStringLiteral("SELECT * FROM note WHERE id = :id"));
     query.bindValue(QStringLiteral(":id"), id);
 
@@ -170,11 +168,11 @@ Note Note::fetch(int id) {
         qWarning() << __func__ << ": " << query.lastError();
     } else {
         if (query.first()) {
-            note = noteFromQuery(query);
+            return noteFromQuery(query);
         }
     }
 
-    return note;
+    return Note();
 }
 
 /**
@@ -787,8 +785,7 @@ QVector<Note> Note::search(const QString &text) {
         qWarning() << __func__ << ": " << query.lastError();
     } else {
         for (int r = 0; query.next(); r++) {
-            Note note = noteFromQuery(query);
-            noteList.append(note);
+            noteList.append(noteFromQuery(query));
         }
     }
 
@@ -3382,7 +3379,11 @@ QString Note::getInsertAttachmentMarkdown(QFile *file, QString fileName,
 QString Note::downloadUrlToMedia(const QUrl &url, bool returnUrlOnly) {
     // try to get the suffix from the url
     QString suffix = url.toString()
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
                          .split(QStringLiteral("."), QString::SkipEmptyParts)
+#else
+                         .split(QStringLiteral("."), Qt::SkipEmptyParts)
+#endif
                          .last();
 
     if (suffix.isEmpty()) {

--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -687,6 +687,31 @@ QVector<Note> Note::fetchAllByNoteSubFolderId(int noteSubFolderId) {
     return noteList;
 }
 
+QVector<int> Note::fetchAllIdsByNoteSubFolderId(int noteSubFolderId)
+{
+    const QSqlDatabase db = QSqlDatabase::database(QStringLiteral("memory"));
+    QSqlQuery query(db);
+
+    QVector<int> noteList;
+    const QString sql = QStringLiteral(
+        "SELECT id FROM note WHERE note_sub_folder_id = "
+        ":note_sub_folder_id ORDER BY file_last_modified DESC");
+
+    query.prepare(sql);
+    query.bindValue(QStringLiteral(":note_sub_folder_id"), noteSubFolderId);
+
+    if (!query.exec()) {
+        qWarning() << __func__ << ": " << query.lastError();
+    } else {
+        for (int r = 0; query.next(); r++) {
+            int id = query.value(QStringLiteral("id")).toInt();
+            noteList.append(id);
+        }
+    }
+
+    return noteList;
+}
+
 /**
  * Gets a list of note ids from a note list
  */

--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -631,7 +631,7 @@ QVector<int> Note::fetchAllIds(int limit, int offset) {
     QSqlQuery query(db);
 
     QVector<int> noteIdList;
-    QString sql = QStringLiteral("SELECT * FROM note ORDER BY id");
+    QString sql = QStringLiteral("SELECT id FROM note ORDER BY id");
 
     if (limit >= 0) {
         sql += QStringLiteral(" LIMIT :limit");
@@ -655,13 +655,9 @@ QVector<int> Note::fetchAllIds(int limit, int offset) {
     if (!query.exec()) {
         qWarning() << __func__ << ": " << query.lastError();
     } else {
-        // there is no way to get the num of rows returned by the query,
-        // so we use static int to save the size after first query to
-        // prevent extra allocations
-        static int r = 0;
-        noteIdList.reserve(r);
-        for (r = 0; query.next(); r++) {
-            noteIdList.append(noteFromQuery(query).getId());
+        for (int r = 0; query.next(); r++) {
+            int id = query.value(QStringLiteral("id")).toInt();
+            noteIdList.append(id);
         }
     }
 

--- a/src/entities/note.h
+++ b/src/entities/note.h
@@ -209,6 +209,8 @@ class Note {
 
     static QVector<Note> fetchAllByNoteSubFolderId(int noteSubFolderId);
 
+    static QVector<int> fetchAllIdsByNoteSubFolderId(int noteSubFolderId);
+
     static QVector<int> noteIdListFromNoteList(const QVector<Note> &noteList);
 
     static int countByNoteSubFolderId(int noteSubFolderId = 0,

--- a/src/entities/notesubfolder.cpp
+++ b/src/entities/notesubfolder.cpp
@@ -46,8 +46,6 @@ NoteSubFolder NoteSubFolder::fetch(int id) {
     const QSqlDatabase db = QSqlDatabase::database(QStringLiteral("memory"));
     QSqlQuery query(db);
 
-    NoteSubFolder noteSubFolder;
-
     query.prepare(QStringLiteral("SELECT * FROM noteSubFolder WHERE id = :id"));
     query.bindValue(QStringLiteral(":id"), id);
 
@@ -55,19 +53,17 @@ NoteSubFolder NoteSubFolder::fetch(int id) {
         qWarning() << __func__ << ": " << query.lastError();
     } else {
         if (query.first()) {
-            noteSubFolder = noteSubFolderFromQuery(query);
+            return noteSubFolderFromQuery(query);
         }
     }
 
-    return noteSubFolder;
+    return NoteSubFolder();
 }
 
 NoteSubFolder NoteSubFolder::fetchByNameAndParentId(const QString& name,
                                                     int parentId) {
     const QSqlDatabase db = QSqlDatabase::database(QStringLiteral("memory"));
     QSqlQuery query(db);
-
-    NoteSubFolder noteSubFolder;
 
     query.prepare(
         QStringLiteral("SELECT * FROM noteSubFolder WHERE name = :name "
@@ -79,11 +75,11 @@ NoteSubFolder NoteSubFolder::fetchByNameAndParentId(const QString& name,
         qWarning() << __func__ << ": " << query.lastError();
     } else {
         if (query.first()) {
-            noteSubFolder = noteSubFolderFromQuery(query);
+            return noteSubFolderFromQuery(query);
         }
     }
 
-    return noteSubFolder;
+    return NoteSubFolder();
 }
 
 /**
@@ -241,8 +237,7 @@ QVector<NoteSubFolder> NoteSubFolder::fetchAll(int limit) {
         qWarning() << __func__ << ": " << query.lastError();
     } else {
         for (int r = 0; query.next(); r++) {
-            const NoteSubFolder noteSubFolder = noteSubFolderFromQuery(query);
-            noteSubFolderList.append(noteSubFolder);
+            noteSubFolderList.append(noteSubFolderFromQuery(query));
         }
     }
 
@@ -288,8 +283,7 @@ QVector<NoteSubFolder> NoteSubFolder::fetchAllByParentId(
         qWarning() << __func__ << ": " << query.lastError();
     } else {
         for (int r = 0; query.next(); r++) {
-            const NoteSubFolder noteSubFolder = noteSubFolderFromQuery(query);
-            noteSubFolderList.append(noteSubFolder);
+            noteSubFolderList.append(noteSubFolderFromQuery(query));
         }
     }
 

--- a/src/entities/tag.cpp
+++ b/src/entities/tag.cpp
@@ -228,8 +228,7 @@ QVector<Tag> Tag::fetchAll() {
         qWarning() << __func__ << ": " << query.lastError();
     } else {
         for (int r = 0; query.next(); r++) {
-            const Tag tag = tagFromQuery(query);
-            tagList.append(tag);
+            tagList.append(tagFromQuery(query));
         }
     }
 
@@ -386,8 +385,7 @@ QVector<Tag> Tag::fetchAllOfNote(const Note &note) {
         qWarning() << __func__ << ": " << query.lastError();
     } else {
         for (int r = 0; query.next(); r++) {
-            const Tag tag = tagFromQuery(query);
-            tagList.append(tag);
+            tagList.append(tagFromQuery(query));
         }
     }
 
@@ -605,8 +603,7 @@ QVector<Tag> Tag::fetchAllWithLinkToNoteNames(const QStringList &noteNameList) {
         qWarning() << __func__ << ": " << query.lastError();
     } else {
         for (int r = 0; query.next(); r++) {
-            const Tag tag = tagFromQuery(query);
-            tagList.append(tag);
+            tagList.append(tagFromQuery(query));
         }
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -9928,7 +9928,11 @@ bool MainWindow::noteTextEditAutoComplete(QStringList &resultList) {
                      .split(QRegularExpression(
                                 QStringLiteral("[^\\w\\d]"),
                                 QRegularExpression::UseUnicodePropertiesOption),
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
                             QString::SkipEmptyParts)
+#else
+                            Qt::SkipEmptyParts)
+#endif
                      .filter(QRegularExpression(
                          QStringLiteral("^") + QRegularExpression::escape(text),
                          QRegularExpression::CaseInsensitiveOption));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5874,9 +5874,7 @@ void MainWindow::filterNotesByNoteSubFolders() {
     noteIdList.reserve(noteSubFolderIds.count());
     for (int noteSubFolderId : Utils::asConst(noteSubFolderIds)) {
         // get all notes of a note sub folder
-        QVector<Note> noteList =
-            Note::fetchAllByNoteSubFolderId(noteSubFolderId);
-        noteIdList << Note::noteIdListFromNoteList(noteList);
+        noteIdList << Note::fetchAllIdsByNoteSubFolderId(noteSubFolderId);
     }
 
     // omit the already hidden notes
@@ -7840,8 +7838,6 @@ void MainWindow::reloadTagTree() {
     ui->tagTreeWidget->clear();
 
     QVector<int> noteSubFolderIds;
-    QVector<int> noteIdList;
-    int untaggedNoteCount = 0;
 
     const auto noteSubFolderWidgetItems =
         ui->noteSubFolderTreeWidget->selectedItems();
@@ -7862,13 +7858,13 @@ void MainWindow::reloadTagTree() {
 
     qDebug() << __func__ << " - 'noteSubFolderIds': " << noteSubFolderIds;
 
+    QVector<int> noteIdList;
+    int untaggedNoteCount = 0;
     // get the notes from the subfolders
     for (int noteSubFolderId : Utils::asConst(noteSubFolderIds)) {
         // get all notes of a note sub folder
-        const QVector<Note> noteList =
-            Note::fetchAllByNoteSubFolderId(noteSubFolderId);
         untaggedNoteCount += Note::countAllNotTagged(noteSubFolderId);
-        noteIdList << Note::noteIdListFromNoteList(noteList);
+        noteIdList << Note::fetchAllIdsByNoteSubFolderId(noteSubFolderId);
     }
 
     // create an item to view all notes
@@ -8175,8 +8171,8 @@ QTreeWidgetItem *MainWindow::addTagToTagTreeWidget(QTreeWidgetItem *parent,
     const auto selectedSubFolderItems =
         ui->noteSubFolderTreeWidget->selectedItems();
 
-    for (const Tag &tagToCount : tagListToCount) {
-        if (selectedSubFolderItems.count() > 1) {
+    if (selectedSubFolderItems.count() > 1) {
+        for (const Tag &tagToCount : tagListToCount) {
             for (QTreeWidgetItem *folderItem : selectedSubFolderItems) {
                 int id = folderItem->data(0, Qt::UserRole).toInt();
                 const NoteSubFolder folder = NoteSubFolder::fetch(id);
@@ -8186,24 +8182,24 @@ QTreeWidgetItem *MainWindow::addTagToTagTreeWidget(QTreeWidgetItem *parent,
                 }
 
                 linkedNoteIds << tagToCount.fetchAllLinkedNoteIdsForFolder(
-                    folder, _showNotesFromAllNoteSubFolders,
-                    NoteSubFolder::isNoteSubfoldersPanelShowNotesRecursively());
+                                     folder, _showNotesFromAllNoteSubFolders,
+                                     NoteSubFolder::isNoteSubfoldersPanelShowNotesRecursively());
             }
-        } else {
+        }
+    } else {
+        for (const Tag &tagToCount : tagListToCount) {
             linkedNoteIds << tagToCount.fetchAllLinkedNoteIds(
-                _showNotesFromAllNoteSubFolders,
-                NoteSubFolder::isNoteSubfoldersPanelShowNotesRecursively());
+                                 _showNotesFromAllNoteSubFolders,
+                                 NoteSubFolder::isNoteSubfoldersPanelShowNotesRecursively());
         }
     }
 
     // remove duplicate note ids
-#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
-    const QSet<int> linkedNoteIdSet = linkedNoteIds.toList().toSet();
-#else
-    const QSet<int> linkedNoteIdSet(linkedNoteIds.begin(), linkedNoteIds.end());
-#endif
+    linkedNoteIds.erase(
+                std::unique(linkedNoteIds.begin(), linkedNoteIds.end()),
+                linkedNoteIds.end());
 
-    const int linkCount = linkedNoteIdSet.count();
+    const int linkCount = linkedNoteIds.count();
     const QString toolTip = tr("show all notes tagged with '%1' (%2)")
                                 .arg(name, QString::number(linkCount));
     auto *item = new QTreeWidgetItem();
@@ -9029,7 +9025,7 @@ void MainWindow::on_tagTreeWidget_customContextMenuRequested(const QPoint pos) {
     }
 
     // don't allow clicking on non-tag items for removing, editing and colors
-    if (item->data(0, Qt::UserRole) <= 0) {
+    if (item->data(0, Qt::UserRole).toInt() <= 0) {
         return;
     }
 


### PR DESCRIPTION
- `Note::fetchAllIds()` now only queries for ids
-  `.append()` method with rvalue ref parameter is used in some places to prevent copies
- New `Note::fetchAllIdsByNoteSubFolderId()` method is implemented to get the ids directly
- Some deprecations warnings fixed

!Upcoming -> add option to disable "note count" with tags so that users can disable it for better performance.