### PR TITLE
Add option to disable note count with tags

### DIFF
--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -1001,6 +1001,8 @@ void SettingsDialog::storePanelSettings() {
     // Tags Panel Options
     settings.setValue(QStringLiteral("tagsPanelHideSearch"),
                       ui->tagsPanelHideSearchCheckBox->isChecked());
+    settings.setValue(QStringLiteral("tagsPanelHideNoteCount"),
+                      ui->tagsPanelHideNoteCountCheckBox->isChecked());
 
     settings.setValue(QStringLiteral("taggingShowNotesRecursively"),
                       ui->taggingShowNotesRecursivelyCheckBox->isChecked());
@@ -1568,6 +1570,8 @@ void SettingsDialog::readPanelSettings() {
     // Tags Panel Options
     ui->tagsPanelHideSearchCheckBox->setChecked(
         settings.value(QStringLiteral("tagsPanelHideSearch")).toBool());
+    ui->tagsPanelHideNoteCountCheckBox->setChecked(
+        settings.value(QStringLiteral("tagsPanelHideNoteCount"), false).toBool());
 
     ui->taggingShowNotesRecursivelyCheckBox->setChecked(
         settings.value(QStringLiteral("taggingShowNotesRecursively")).toBool());
@@ -1618,7 +1622,7 @@ void SettingsDialog::loadShortcutSettings() {
     QColor shortcutButtonInactiveColor =
         darkMode ? Qt::darkGray : palette.color(QPalette::Mid);
 
-    QList<QMenu *> menus = mainWindow->menuList();
+    const QList<QMenu *> menus = mainWindow->menuList();
     ui->shortcutSearchLineEdit->clear();
     ui->shortcutTreeWidget->clear();
     ui->shortcutTreeWidget->setColumnCount(3);
@@ -1628,7 +1632,7 @@ void SettingsDialog::loadShortcutSettings() {
                                            << QStringLiteral("noteFoldersMenu");
 
     // loop through all menus
-    foreach (QMenu *menu, menus) {
+    for (const QMenu *menu : menus) {
         if (disabledMenuNames.contains(menu->objectName())) {
             continue;
         }
@@ -1689,7 +1693,7 @@ void SettingsDialog::loadShortcutSettings() {
                           ":icons/breeze-qownnotes/16x16/dialog-cancel.svg"))));
 
             connect(disableShortcutButton, &QPushButton::pressed, this,
-                [this, keyWidget]() {
+                [keyWidget]() {
                     keyWidget->setKeySequence(QKeySequence(""));
                 });
 

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
-    <height>600</height>
+    <width>1078</width>
+    <height>1194</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -397,7 +397,7 @@
          <item>
           <widget class="QStackedWidget" name="settingsStackedWidget">
            <property name="currentIndex">
-            <number>1</number>
+            <number>16</number>
            </property>
            <widget class="QWidget" name="noteFoldersPage">
             <layout class="QGridLayout" name="gridLayout_19">
@@ -979,6 +979,7 @@
                    <font>
                     <weight>50</weight>
                     <bold>false</bold>
+                    <kerning>true</kerning>
                    </font>
                   </property>
                   <property name="styleSheet">
@@ -3468,8 +3469,8 @@
                           <rect>
                            <x>0</x>
                            <y>0</y>
-                           <width>430</width>
-                           <height>538</height>
+                           <width>310</width>
+                           <height>430</height>
                           </rect>
                          </property>
                          <layout class="QGridLayout" name="gridLayout_55">
@@ -4628,7 +4629,7 @@ Just test yourself if you get sync conflicts and set a higher value if so.</stri
                 <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:14pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif'; font-size:9pt;&quot;&gt;portable mode information will be loaded here&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="openExternalLinks">
@@ -5741,6 +5742,13 @@ git config --global user.name &quot;Your name&quot;</string>
                  <widget class="QCheckBox" name="tagsPanelHideSearchCheckBox">
                   <property name="text">
                    <string>Hide 'Find or create tag' search</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="1" column="0">
+                 <widget class="QCheckBox" name="tagsPanelHideNoteCountCheckBox">
+                  <property name="text">
+                   <string>Hide 'Note count' with tags (increases performance)</string>
                   </property>
                  </widget>
                 </item>

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1078</width>
-    <height>1194</height>
+    <width>800</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -397,7 +397,7 @@
          <item>
           <widget class="QStackedWidget" name="settingsStackedWidget">
            <property name="currentIndex">
-            <number>16</number>
+            <number>1</number>
            </property>
            <widget class="QWidget" name="noteFoldersPage">
             <layout class="QGridLayout" name="gridLayout_19">
@@ -979,7 +979,6 @@
                    <font>
                     <weight>50</weight>
                     <bold>false</bold>
-                    <kerning>true</kerning>
                    </font>
                   </property>
                   <property name="styleSheet">
@@ -3469,8 +3468,8 @@
                           <rect>
                            <x>0</x>
                            <y>0</y>
-                           <width>310</width>
-                           <height>430</height>
+                           <width>430</width>
+                           <height>538</height>
                           </rect>
                          </property>
                          <layout class="QGridLayout" name="gridLayout_55">
@@ -4629,7 +4628,7 @@ Just test yourself if you get sync conflicts and set a higher value if so.</stri
                 <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:14pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif'; font-size:9pt;&quot;&gt;portable mode information will be loaded here&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="openExternalLinks">


### PR DESCRIPTION
Add option to disable counting notes for every tag. This increases performance by quite a margin when reloading the tag tree.
 - Count will still be visible for "All Notes" and "Untagged Notes"

#943