### PR TITLE
Respect tab stop width and tab vs space in fakevim mode

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -604,12 +604,8 @@ void MainWindow::initFakeVim(QOwnNotesMarkdownTextEdit *noteTextEdit) {
     auto proxy = new FakeVimProxy(noteTextEdit, this, handler);
 
     QSettings settings;
-    if (settings.value(QStringLiteral("Editor/useTabIndent")).toBool()) {
-        FakeVim::Internal::theFakeVimSettings()->item("et")->setValue(true);
-    } else {
-        FakeVim::Internal::theFakeVimSettings()->item("et")->setValue(true);
-    }
-
+    bool setExpandTab = settings.value(QStringLiteral("Editor/useTabIndent")).toBool();
+    FakeVim::Internal::theFakeVimSettings()->item("et")->setValue(setExpandTab);
     auto width = settings.value("Editor/indentSize", 4).toInt();
     FakeVim::Internal::theFakeVimSettings()->item("ts")->setValue(width);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -103,6 +103,7 @@
 #include "helpers/qownnotesmarkdownhighlighter.h"
 #include <diff_match_patch.h>
 #include "libraries/fakevim/fakevim/fakevimhandler.h"
+#include "libraries/fakevim/fakevim/fakevimactions.h"
 #include "libraries/sonnet/src/core/speller.h"
 #include "release.h"
 #include "services/databaseservice.h"
@@ -601,6 +602,16 @@ void MainWindow::initFakeVim(QOwnNotesMarkdownTextEdit *noteTextEdit) {
     handler->setupWidget();
 
     auto proxy = new FakeVimProxy(noteTextEdit, this, handler);
+
+    QSettings settings;
+    if (settings.value(QStringLiteral("Editor/useTabIndent")).toBool()) {
+        FakeVim::Internal::theFakeVimSettings()->item("et")->setValue(true);
+    } else {
+        FakeVim::Internal::theFakeVimSettings()->item("et")->setValue(true);
+    }
+
+    auto width = settings.value("Editor/indentSize", 4).toInt();
+    FakeVim::Internal::theFakeVimSettings()->item("ts")->setValue(width);
 
     QObject::connect(handler,
                      &FakeVim::Internal::FakeVimHandler::commandBufferChanged,


### PR DESCRIPTION
https://github.com/pbek/QOwnNotes/issues/1875

I have tried very hard to fix "Ctrl + V", it deactivates in fakeVim correctly but for some reason the text never gets pasted. It is probably because of some shortcut conflict or some other thing. Not sure. Any ideas?