### PR TITLE
Add fetchNoteIdByName to fetch only note Id

### DIFF
--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -527,6 +527,32 @@ Note Note::fetchByName(const QString &name,
     return fetchByName(name, noteSubFolderId);
 }
 
+int Note::fetchNoteIdByName(const QString &name, int noteSubFolderId)
+{
+    const QSqlDatabase db = QSqlDatabase::database(QStringLiteral("memory"));
+    QSqlQuery query(db);
+
+    // get the active note subfolder id if none was set
+    if (noteSubFolderId == -1) {
+        noteSubFolderId = NoteSubFolder::activeNoteSubFolderId();
+    }
+
+    query.prepare(
+        QStringLiteral("SELECT id FROM note WHERE name = :name AND "
+                       "note_sub_folder_id = :note_sub_folder_id"));
+    query.bindValue(QStringLiteral(":name"), name);
+    query.bindValue(QStringLiteral(":note_sub_folder_id"), noteSubFolderId);
+
+    if (!query.exec()) {
+        qWarning() << __func__ << ": " << query.lastError();
+    } else {
+        if (query.first()) {
+            return query.value(QStringLiteral("id")).toInt();
+        }
+    }
+    return -1;
+}
+
 Note Note::fetchByName(const QString &name, int noteSubFolderId) {
     const QSqlDatabase db = QSqlDatabase::database(QStringLiteral("memory"));
     QSqlQuery query(db);

--- a/src/entities/note.h
+++ b/src/entities/note.h
@@ -62,6 +62,8 @@ class Note {
         const QString &noteSubFolderPathData,
         const QString& pathDataSeparator = QStringLiteral("\n"));
 
+    static int fetchNoteIdByName(const QString &name, int noteSubFolderId = -1);
+
     static QVector<Note> fetchAll(int limit = -1);
 
     static QVector<Note> fetchAllNotTagged(int activeNoteSubFolderId);

--- a/src/entities/tag.cpp
+++ b/src/entities/tag.cpp
@@ -725,6 +725,7 @@ QVector<int> Tag::fetchAllLinkedNoteIds(int tagId, const bool fromAllSubfolders,
             int noteId = Note::fetchNoteIdByName(name, noteSubFolderId);
             noteIdList.append(noteId);
         }
+        return noteIdList;
     }
 
     DatabaseService::closeDatabaseConnection(db, query);

--- a/src/entities/tag.cpp
+++ b/src/entities/tag.cpp
@@ -683,7 +683,6 @@ QVector<int> Tag::fetchAllLinkedNoteIds(int tagId, const bool fromAllSubfolders,
                                         const bool recursive) {
     QSqlDatabase db = DatabaseService::getNoteFolderDatabase();
     QSqlQuery query(db);
-    QVector<int> noteIdList;
 
     if (fromAllSubfolders) {
         // 'All notes' selected in note subfolder panel
@@ -712,6 +711,7 @@ QVector<int> Tag::fetchAllLinkedNoteIds(int tagId, const bool fromAllSubfolders,
     if (!query.exec()) {
         qWarning() << __func__ << ": " << query.lastError();
     } else {
+        QVector<int> noteIdList;
         for (int r = 0; query.next(); r++) {
             // always keep in mind that note_file_name is no file name,
             // but the base name (so "my-note", instead of "my-note.md")
@@ -719,16 +719,17 @@ QVector<int> Tag::fetchAllLinkedNoteIds(int tagId, const bool fromAllSubfolders,
                 query.value(QStringLiteral("note_file_name")).toString();
             const QString &noteSubFolderPathData =
                 query.value(QStringLiteral("note_sub_folder_path")).toString();
-            const Note &note = Note::fetchByName(name, noteSubFolderPathData,
-                                                 QStringLiteral("/"));
-
-            noteIdList.append(note.getId());
+            int noteSubFolderId =
+                NoteSubFolder::fetchByPathData(noteSubFolderPathData, QStringLiteral("/"))
+                    .getId();
+            int noteId = Note::fetchNoteIdByName(name, noteSubFolderId);
+            noteIdList.append(noteId);
         }
     }
 
     DatabaseService::closeDatabaseConnection(db, query);
 
-    return noteIdList;
+    return QVector<int>();
 }
 
 /**
@@ -775,10 +776,11 @@ QVector<int> Tag::fetchAllLinkedNoteIdsForFolder(int tagId,
                 query.value(QStringLiteral("note_file_name")).toString();
             const QString &noteSubFolderPathData =
                 query.value(QStringLiteral("note_sub_folder_path")).toString();
-            const Note &note = Note::fetchByName(name, noteSubFolderPathData,
-                                                 QStringLiteral("/"));
-
-            noteIdList.append(note.getId());
+            int noteSubFolderId =
+                NoteSubFolder::fetchByPathData(noteSubFolderPathData, QStringLiteral("/"))
+                    .getId();
+            int noteId = Note::fetchNoteIdByName(name, noteSubFolderId);
+            noteIdList.append(noteId);
         }
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -8183,8 +8183,6 @@ QTreeWidgetItem *MainWindow::addTagToTagTreeWidget(QTreeWidgetItem *parent,
     const int tagId = tag._id;
     const QString name = tag._name;
     auto hideCount = QSettings().value("tagsPanelHideNoteCount", false).toBool();
-    const bool isShowNotesRecursively =
-            NoteSubFolder::isNoteSubfoldersPanelShowNotesRecursively();
 
     QVector<int> linkedNoteIds;
     if (!hideCount) {
@@ -8192,8 +8190,12 @@ QTreeWidgetItem *MainWindow::addTagToTagTreeWidget(QTreeWidgetItem *parent,
                     Tag::fetchTagIdsRecursivelyByParentId(tagId) : QVector<int>{tag._id};
         const auto selectedSubFolderItems =
                 ui->noteSubFolderTreeWidget->selectedItems();
+        const bool showNotesFromAllSubFolders = this->_showNotesFromAllNoteSubFolders;
+        const bool isShowNotesRecursively =
+                NoteSubFolder::isNoteSubfoldersPanelShowNotesRecursively();
 
         if (selectedSubFolderItems.count() > 1) {
+            linkedNoteIds.reserve(tagIdListToCount.size());
             for (const int tagIdToCount : tagIdListToCount) {
                 for (QTreeWidgetItem *folderItem : selectedSubFolderItems) {
                     int id = folderItem->data(0, Qt::UserRole).toInt();
@@ -8205,15 +8207,16 @@ QTreeWidgetItem *MainWindow::addTagToTagTreeWidget(QTreeWidgetItem *parent,
 
                     linkedNoteIds << Tag::fetchAllLinkedNoteIdsForFolder(
                                          tagIdToCount,
-                                         folder, _showNotesFromAllNoteSubFolders,
+                                         folder, showNotesFromAllSubFolders,
                                          isShowNotesRecursively);
                 }
             }
         } else {
+            linkedNoteIds.reserve(tagIdListToCount.size());
             for (const int tagToCount : tagIdListToCount) {
                 linkedNoteIds << Tag::fetchAllLinkedNoteIds(
                                      tagToCount,
-                                     _showNotesFromAllNoteSubFolders,
+                                     showNotesFromAllSubFolders,
                                      isShowNotesRecursively);
             }
         }


### PR DESCRIPTION
#943

With this commit almost all of the lag with around 3000 tags is gone. (There will still be lag if multiple folders are selected, but that is *rather difficult* to get around because we have a large amount of data to work with)