### PR TITLE
Dont reloadTagTree multiple times during startup

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11943,6 +11943,9 @@ Qt::SortOrder MainWindow::toQtOrder(int order) {
 void MainWindow::updatePanelsSortOrder() {
     updateNotesPanelSortOrder();
     reloadNoteSubFolderTree();
+    // do not reload it again, it has already been reloaded when
+    // updateNotesPanelSortOrder() was called
+    //reloadTagTree();
 }
 
 void MainWindow::updateNotesPanelSortOrder() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11943,7 +11943,6 @@ Qt::SortOrder MainWindow::toQtOrder(int order) {
 void MainWindow::updatePanelsSortOrder() {
     updateNotesPanelSortOrder();
     reloadNoteSubFolderTree();
-    reloadTagTree();
 }
 
 void MainWindow::updateNotesPanelSortOrder() {


### PR DESCRIPTION
`reloadTagTree()` is called **3** times during startup.

# 1
```bt
1 MainWindow::reloadTagTree                           mainwindow.cpp 7858 0x55555562ba97 
2 MainWindow::setupTags                               mainwindow.cpp 8364 0x55555562f8a4 
3 MainWindow::loadNoteDirectoryList                   mainwindow.cpp 2148 0x555555604fbc 
4 MainWindow::buildNotesIndexAndLoadNoteDirectoryList mainwindow.cpp 1031 0x5555555fd0e3 
5 MainWindow::MainWindow                              mainwindow.cpp 290  0x5555555f7111 
6 main                                                main.cpp       616  0x5555555df24a 
```

# 2

```bt
1 MainWindow::reloadTagTree             mainwindow.cpp 7858  0x55555562ba97 
2 MainWindow::setupTags                 mainwindow.cpp 8364  0x55555562f8a4 
3 MainWindow::loadNoteDirectoryList     mainwindow.cpp 2148  0x555555604fbc 
4 MainWindow::updateNotesPanelSortOrder mainwindow.cpp 11962 0x555555647330 
5 MainWindow::updatePanelsSortOrder     mainwindow.cpp 11944 0x5555556470ae 
6 MainWindow::MainWindow                mainwindow.cpp 399   0x5555555f7e4e 
7 main                                  main.cpp       616   0x5555555df24a 
```

# 3

```bt
1 MainWindow::reloadTagTree             mainwindow.cpp 7858  0x55555562ba97 
5 MainWindow::updatePanelsSortOrder     mainwindow.cpp 11944 0x5555556470ae 
6 MainWindow::MainWindow                mainwindow.cpp 399   0x5555555f7e4e 
7 main                                  main.cpp       616   0x5555555df24a 
```

With this commit we are down to two.