### PR TITLE
Prevent setting empty folder name

### DIFF
--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -2635,6 +2635,13 @@ void SettingsDialog::on_noteFolderNameLineEdit_editingFinished() {
                        .remove(QStringLiteral("\n"))
                        .trimmed();
     text.truncate(50);
+
+    // fallback to directory name in case name edit is empty
+    if (text.isEmpty()) {
+        const QString localPath = ui->noteFolderLocalPathLineEdit->text();
+        text = QDir(localPath).dirName();
+    }
+
     _selectedNoteFolder.setName(text);
     _selectedNoteFolder.store();
 


### PR DESCRIPTION
Prevent setting empty folder name; fallback to local directory name instead.

![image](https://user-images.githubusercontent.com/73212737/99154613-d3d9be80-26b9-11eb-8552-b98d738faff3.png)
![image](https://user-images.githubusercontent.com/73212737/99154630-07b4e400-26ba-11eb-8a2f-515045d032a3.png)
