### PR TITLE
Do not display subfolder actions when right clicking empty space in note list panel

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10360,12 +10360,17 @@ void MainWindow::openCurrentNoteInTab() {
 void MainWindow::on_noteTreeWidget_customContextMenuRequested(
     const QPoint pos) {
     auto *item = ui->noteTreeWidget->itemAt(pos);
+
+    // if the user clicks at empty space, this is null and if it isn't handled
+    // QON crashes
+    if (item == nullptr) {
+        return;
+    }
+
     const QPoint globalPos = ui->noteTreeWidget->mapToGlobal(pos);
     const int type = item == nullptr ?
          0 : item->data(0, Qt::UserRole + 1).toInt();
 
-    // if the user clicks at empty space, this is null and if it isn't handled
-    // QON crashes
     if (item == nullptr || type == FolderType) {
         openNoteSubFolderContextMenu(globalPos, ui->noteTreeWidget);
     } else if (type == NoteType) {
@@ -10610,7 +10615,7 @@ void MainWindow::on_noteTreeWidget_itemChanged(QTreeWidgetItem *item,
     if (item == nullptr) {
         return;
     }
-    
+
     // handle note subfolder renaming in a note tree
     if (item->data(0, Qt::UserRole + 1) == FolderType) {
         on_noteSubFolderTreeWidget_itemChanged(item, column);


### PR DESCRIPTION
Hides subfolder context menu actions in note list panel when subfolders are not used for the current folder.