### PR TITLE
Remove rename/remove subfolder context menu option if no active subfolder

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10813,8 +10813,14 @@ void MainWindow::openNoteSubFolderContextMenu(const QPoint globalPos,
     QMenu menu;
     QAction *newNoteAction = menu.addAction(tr("New note"));
     QAction *newAction = menu.addAction(tr("New subfolder"));
-    QAction *renameAction = menu.addAction(tr("Rename subfolder"));
-    QAction *removeAction = menu.addAction(tr("Remove selected folders"));
+    QAction *renameAction(nullptr);
+    QAction *removeAction(nullptr);
+
+    if (NoteFolder::currentNoteFolder().getActiveNoteSubFolder().isFetched()) {
+        renameAction = menu.addAction(tr("Rename subfolder"));
+        removeAction = menu.addAction(tr("Remove selected folders"));
+    }
+
     QAction *showInFileManagerAction =
         menu.addAction(tr("Show folder in file manager"));
     menu.addAction(ui->action_Reload_note_folder);


### PR DESCRIPTION
It is currently possible, from the subfolder pane, to select the current folder or 'All notes' and, from the context menu, to select 'Rename subfolder' or 'Remove selected folder'. 

Actions would fail, but they should not be visible in the context menu, in the first place.

![image](https://user-images.githubusercontent.com/73212737/99678605-ac04a500-2a83-11eb-8e98-4e3f8329b4e7.png)
