### PR TITLE
Rework tags for performance

### DIFF
--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -747,27 +747,6 @@ QVector<int> Note::noteIdListFromNoteList(const QVector<Note> &noteList) {
 }
 
 /**
- * Returns all notes that are not tagged
- */
-QVector<Note> Note::fetchAllNotTagged(int activeNoteSubFolderId) {
-    QVector<Note> noteList;
-    if (activeNoteSubFolderId < 0) {
-        noteList = Note::fetchAll();
-    } else {
-        noteList = Note::fetchAllByNoteSubFolderId(activeNoteSubFolderId);
-    }
-    QVector<Note> untaggedNoteList;
-    untaggedNoteList.reserve(noteList.size());
-
-    QVector<Note>::const_iterator i;
-    for (i = noteList.constBegin(); i != noteList.constEnd(); ++i) {
-        const int tagCount = Tag::countAllOfNote(*i);
-        if (tagCount == 0) untaggedNoteList.append(*i);
-    }
-    return untaggedNoteList;
-}
-
-/**
  * Returns all notes names that are not tagged
  */
 QVector<int> Note::fetchAllNotTaggedIds() {
@@ -777,8 +756,9 @@ QVector<int> Note::fetchAllNotTaggedIds() {
 
     QVector<Note>::const_iterator it = noteList.constBegin();
     for (; it != noteList.constEnd(); ++it) {
-        const int tagCount = Tag::countAllOfNote(*it);
-        if (tagCount == 0) untaggedNoteIdList << it->getId();
+        if (!Tag::noteHasTags(*it, QString())) {
+            untaggedNoteIdList << it->getId();
+        }
     }
 
     return untaggedNoteIdList;
@@ -788,7 +768,23 @@ QVector<int> Note::fetchAllNotTaggedIds() {
  * Counts all notes that are not tagged
  */
 int Note::countAllNotTagged(int activeNoteSubFolderId) {
-    return Note::fetchAllNotTagged(activeNoteSubFolderId).count();
+    QVector<Note> noteList;
+    QString path;
+    if (activeNoteSubFolderId < 0) {
+        noteList = Note::fetchAll();
+    } else {
+        noteList = Note::fetchAllByNoteSubFolderId(activeNoteSubFolderId);
+        path = NoteSubFolder::fetch(activeNoteSubFolderId).relativePath();
+    }
+
+    QVector<Note>::const_iterator i;
+    int count = 0;
+    for (i = noteList.constBegin(); i != noteList.constEnd(); ++i) {
+        if (!Tag::noteHasTags(*i, path)) {
+            count++;
+        }
+    }
+    return count;
 }
 
 QVector<Note> Note::search(const QString &text) {

--- a/src/entities/note.h
+++ b/src/entities/note.h
@@ -66,8 +66,6 @@ class Note {
 
     static QVector<Note> fetchAll(int limit = -1);
 
-    static QVector<Note> fetchAllNotTagged(int activeNoteSubFolderId);
-
     static QVector<int> fetchAllNotTaggedIds();
 
     static int countAllNotTagged(int activeNoteSubFolderId = -1);

--- a/src/entities/tag.h
+++ b/src/entities/tag.h
@@ -75,11 +75,12 @@ class Tag : protected TagHeader {
 
     bool isLinkedToNote(const Note &note) const;
 
-    int countLinkedNoteFileNames(const bool fromAllSubfolder,
-                                 const bool recursive) const;
+    static int countLinkedNoteFileNames(int tagId, bool fromAllSubfolders,
+                                        bool recursive);
 
-    int countLinkedNoteFileNamesForNoteSubFolder(
-        const NoteSubFolder &noteSubFolder, const bool recursive) const;
+    static int countLinkedNoteFileNamesForNoteSubFolder(
+        int tagId, const NoteSubFolder &noteSubFolder,
+        bool fromAllSubfolders, bool recursive);
 
     int getParentId() const;
 
@@ -138,7 +139,7 @@ class Tag : protected TagHeader {
 
     static int countAllParentId(const int parentId);
 
-    static int countAllOfNote(const Note &note);
+    static bool noteHasTags(const Note &note, const QString& path);
 
     static void setAsActive(const int tagId);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -7993,7 +7993,6 @@ void MainWindow::reloadTagTree() {
         noteIdList << Note::fetchAllIdsByNoteSubFolderId(noteSubFolderId);
     }
 
-
     // create an item to view all notes
     int linkCount =
         _showNotesFromAllNoteSubFolders ? Note::countAll() : noteIdList.count();
@@ -8015,7 +8014,6 @@ void MainWindow::reloadTagTree() {
 
     // this time, the tags come first
     buildTagTreeForParentItem();
-
     // and get sorted
     if (settings.value(QStringLiteral("tagsPanelSort")).toInt() ==
         SORT_ALPHABETICAL) {
@@ -8336,7 +8334,6 @@ QTreeWidgetItem *MainWindow::addTagToTagTreeWidget(QTreeWidgetItem *parent,
             }
         }
     }
-
 
     const int linkCount = count;
     const QString toolTip = tr("show all notes tagged with '%1' (%2)")
@@ -10687,7 +10684,9 @@ void MainWindow::on_noteSubFolderTreeWidget_currentItemChanged(
         filterNotes();
     }
 
-    reloadTagTree();
+    if (isTagsEnabled()) {
+        reloadTagTree();
+    }
 }
 
 void MainWindow::on_noteSubFolderTreeWidget_itemSelectionChanged() {
@@ -10696,8 +10695,12 @@ void MainWindow::on_noteSubFolderTreeWidget_itemSelectionChanged() {
     if (ui->noteSubFolderTreeWidget->selectedItems().count() <= 1) {
         return;
     }
+
     filterNotes();
-    reloadTagTree();
+
+    if (isTagsEnabled()) {
+        reloadTagTree();
+    }
 }
 
 void MainWindow::clearTagFilteringColumn() {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -954,8 +954,6 @@ private:
     void createNewNote(QString noteName = QString(),
                        bool withNameAppend = true);
 
-    bool selectedNotesHaveTags();
-
     void initTagButtonScrollArea();
 
     static QIcon getSystemTrayIcon();


### PR DESCRIPTION
- Tag tree reloads are much faster now (2x faster). There should be no lag even with huge trees 3000+ note tag links
- Tag tree is not reloaded if the tag panel is not visible
- Removed an unused method in mainwindow