### PR TITLE
Use Note::isFetched instead of exists()

### DIFF
--- a/src/api/noteapi.cpp
+++ b/src/api/noteapi.cpp
@@ -92,7 +92,7 @@ bool NoteApi::addTag(const QString& tagName) {
     }
 
     Note note = Note::fetch(_id);
-    if (!note.exists()) {
+    if (!note.isFetched()) {
         return false;
     }
 
@@ -119,7 +119,7 @@ bool NoteApi::removeTag(QString tagName) {
     }
 
     Note note = Note::fetch(_id);
-    if (!note.exists()) {
+    if (!note.isFetched()) {
         return false;
     }
 
@@ -135,7 +135,7 @@ bool NoteApi::removeTag(QString tagName) {
 bool NoteApi::renameNoteFile(const QString &newName) {
     Note note = Note::fetch(_id);
 
-    if (note.exists()) {
+    if (note.isFetched()) {
         return note.renameNoteFile(newName);
     }
 

--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -1552,7 +1552,7 @@ bool Note::handleNoteTextFileName() {
         const QString nameBase = name;
 
         // check if note with this filename already exists
-        while (Note::fetchByFileName(fileName).exists()) {
+        while (Note::fetchByFileName(fileName).isFetched()) {
             // find new filename for the note
             name =
                 nameBase + QStringLiteral(" ") + QString::number(++nameCount);

--- a/src/entities/notehistory.cpp
+++ b/src/entities/notehistory.cpp
@@ -99,7 +99,7 @@ bool NoteHistoryItem::isValid() const {
 
 bool NoteHistoryItem::isNoteValid() const {
     Note note = getNote();
-    return note.exists();
+    return note.isFetched();
 }
 
 bool NoteHistoryItem::operator==(const NoteHistoryItem &item) const {

--- a/src/entities/tag.cpp
+++ b/src/entities/tag.cpp
@@ -1173,7 +1173,7 @@ void Tag::removeBrokenLinks() {
                 Note::fetchByName(noteFileName, noteSubFolder.getId());
 
             // remove note tag link if note doesn't exist
-            if (!note.exists()) {
+            if (!note.isFetched()) {
                 const int id = query.value(QStringLiteral("id")).toInt();
                 removeNoteLinkById(id);
             }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -7358,7 +7358,7 @@ void MainWindow::gotoNoteBookmark(int slot) {
     NoteHistoryItem item = noteBookmarks[slot];
 
     // check if the note (still) exists
-    if (item.getNote().exists()) {
+    if (item.getNote().isFetched()) {
         ui->noteTextEdit->setFocus();
         setCurrentNoteFromHistoryItem(item);
 

--- a/src/services/scriptingservice.cpp
+++ b/src/services/scriptingservice.cpp
@@ -1719,7 +1719,7 @@ bool ScriptingService::noteExistsByFileName(const QString &fileName,
         return false;
     }
 
-    return note.exists();
+    return note.isFetched();
 }
 
 /**


### PR DESCRIPTION
It doesn't replace all usages of `exists()`, only those where a second fetch is pointless