### PR TITLE
Allow 'copy code' for inline code blocks

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6846,8 +6846,9 @@ void MainWindow::noteTextEditCustomContextMenuRequested(
             // copy the text from a copy block around currentTextBlock to the
             // clipboard
             if (isCodeSpan) {
-                const auto codeSpanRange = ui->noteTextEdit->highlighter()->codeSpanRange(currentTextBlock.blockNumber(),
-                                                                                          noteTextEdit->cursorForPosition(pos).positionInBlock());
+                const auto codeSpanRange = ui->noteTextEdit->highlighter()->getSpanRange(MarkdownHighlighter::RangeType::CodeSpan,
+                                                                                         currentTextBlock.blockNumber(),
+                                                                                         noteTextEdit->cursorForPosition(pos).positionInBlock());
                 QApplication::clipboard()->setText(currentTextBlock.text().mid(codeSpanRange.first + 1,
                                                                                codeSpanRange.second - codeSpanRange.first - 1));
             } else {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -6728,8 +6728,11 @@ void MainWindow::noteTextEditCustomContextMenuRequested(
     const QTextBlock &currentTextBlock =
         noteTextEdit->cursorForPosition(pos).block();
     const int userState = currentTextBlock.userState();
+    const bool isCodeSpan = ui->noteTextEdit->highlighter()->isPosInACodeSpan(currentTextBlock.blockNumber(),
+                                                                              noteTextEdit->cursorForPosition(pos).positionInBlock());
+
     copyCodeBlockAction->setEnabled(
-        MarkdownHighlighter::isCodeBlock(userState));
+        MarkdownHighlighter::isCodeBlock(userState) || isCodeSpan);
 
     menu->addSeparator();
 
@@ -6842,7 +6845,14 @@ void MainWindow::noteTextEditCustomContextMenuRequested(
         } else if (selectedItem == copyCodeBlockAction) {
             // copy the text from a copy block around currentTextBlock to the
             // clipboard
-            Utils::Gui::copyCodeBlockText(currentTextBlock);
+            if (isCodeSpan) {
+                const auto codeSpanRange = ui->noteTextEdit->highlighter()->codeSpanRange(currentTextBlock.blockNumber(),
+                                                                                          noteTextEdit->cursorForPosition(pos).positionInBlock());
+                QApplication::clipboard()->setText(currentTextBlock.text().mid(codeSpanRange.first + 1,
+                                                                               codeSpanRange.second - codeSpanRange.first - 1));
+            } else {
+                Utils::Gui::copyCodeBlockText(currentTextBlock);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/pbek/QOwnNotes/issues/1967
Requires PR: https://github.com/pbek/qmarkdowntextedit/pull/131