### PR TITLE
Corrected a typo from "node" to "mode"

### DIFF
--- a/webpage/src/installation/windows.md
+++ b/webpage/src/installation/windows.md
@@ -18,7 +18,7 @@ Use `QOwnNotesPortable.bat` to run QOwnNotes in **portable mode** where everythi
 stored in your `QOwnNotes` folder.
 
 ::: tip
-You don't need the portable node if you just don't have Administration permissions
+You don't need the portable mode if you just don't have Administration permissions
 to your computer. QOwnNotes doesn't need to be installed!
 :::
 


### PR DESCRIPTION
The suggested change is under the Tip in Portable Mode for installing QOwnNotes on Windows.
![pictureOfTips](https://user-images.githubusercontent.com/72032538/102460744-7399bc00-406d-11eb-89cd-02303ab9e2d1.PNG)
