### PR TITLE
Replace FindAction with a more slick command bar with improved filtering

### DIFF
--- a/src/QOwnNotes.pro
+++ b/src/QOwnNotes.pro
@@ -173,7 +173,9 @@ SOURCES += main.cpp\
     widgets/layoutwidget.cpp \
     dialogs/serverbookmarksimportdialog.cpp \
     dialogs/websockettokendialog.cpp \
-    dialogs/imagedialog.cpp
+    dialogs/imagedialog.cpp \
+    dialogs/commandbar.cpp \
+    models/commandmodel.cpp
 
 HEADERS  += mainwindow.h \
     build_number.h \
@@ -268,7 +270,9 @@ HEADERS  += mainwindow.h \
     widgets/layoutwidget.h \
     dialogs/serverbookmarksimportdialog.h \
     dialogs/websockettokendialog.h \
-    dialogs/imagedialog.h
+    dialogs/imagedialog.h \
+    dialogs/commandbar.h \
+    models/commandmodel.h
 
 FORMS    += mainwindow.ui \
     dialogs/attachmentdialog.ui \

--- a/src/dialogs/commandbar.cpp
+++ b/src/dialogs/commandbar.cpp
@@ -1,0 +1,383 @@
+#include "commandbar.h"
+
+#include <QAction>
+#include <QPainter>
+#include <QTreeView>
+#include <QLineEdit>
+#include <QKeyEvent>
+#include <QStyledItemDelegate>
+#include <QSortFilterProxyModel>
+#include <QTextDocument>
+#include <QVBoxLayout>
+#include <QCoreApplication>
+#include <QMenu>
+
+#include "models/commandmodel.h"
+#include "utils/misc.h"
+#include "libraries/fuzzy/fts_fuzzy_match.h"
+
+class CommandBarFilterModel : public QSortFilterProxyModel
+{
+public:
+    CommandBarFilterModel(QObject *parent = nullptr)
+        : QSortFilterProxyModel(parent)
+    {
+    }
+
+    Q_SLOT void setFilterString(const QString &string)
+    {
+        beginResetModel();
+        m_pattern = string;
+        endResetModel();
+    }
+
+protected:
+    bool lessThan(const QModelIndex &sourceLeft, const QModelIndex &sourceRight) const override
+    {
+        const int l = sourceLeft.data(CommandModel::Score).toInt();
+        const int r = sourceRight.data(CommandModel::Score).toInt();
+        return l < r;
+    }
+
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override
+    {
+        if (m_pattern.isEmpty())
+            return true;
+
+        int score = 0;
+        const auto idx = sourceModel()->index(sourceRow, 0, sourceParent);
+        const auto actionName = idx.data().toString().splitRef(QLatin1Char(':')).at(1);
+        const bool res = fts::fuzzy_match_sequential(m_pattern, actionName, score);
+        sourceModel()->setData(idx, score, CommandModel::Score);
+        return res;
+    }
+
+private:
+    QString m_pattern;
+};
+
+class CommandBarStyleDelegate : public QStyledItemDelegate
+{
+public:
+    CommandBarStyleDelegate(QObject *parent = nullptr)
+        : QStyledItemDelegate(parent)
+    {
+    }
+
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override
+    {
+        QStyleOptionViewItem options = option;
+        initStyleOption(&options, index);
+
+        QTextDocument doc;
+
+        const auto original = index.data().toString();
+
+        const auto strs = index.data().toString().split(QLatin1Char(':'));
+        QString str = strs.at(1);
+        const QString nameColor = option.palette.color(QPalette::Link).name();
+        fts::to_fuzzy_matched_display_string(m_filterString, str, QStringLiteral("<b style=\"color:%1;\">").arg(nameColor), QStringLiteral("</b>"));
+
+        const QString component = QStringLiteral("<span style=\"color: gray;\">") + strs.at(0) + QStringLiteral(": </span>");
+
+        doc.setHtml(component + str);
+        doc.setDocumentMargin(2);
+
+        painter->save();
+
+        // paint background
+        if (option.state & QStyle::State_Selected) {
+            painter->fillRect(option.rect, option.palette.highlight());
+        } else {
+            painter->fillRect(option.rect, option.palette.base());
+        }
+
+        options.text = QString(); // clear old text
+        options.widget->style()->drawControl(QStyle::CE_ItemViewItem, &options, painter, options.widget);
+
+        // fix stuff for rtl
+        // QTextDocument doesn't work with RTL text out of the box so we give it a hand here by increasing
+        // the text width to our rect size. Icon displacement is also calculated here because 'translate()'
+        // later will not work.
+        const bool rtl = original.isRightToLeft();
+        if (rtl) {
+            auto r = options.widget->style()->subElementRect(QStyle::SE_ItemViewItemText, &options, options.widget);
+            auto hasIcon = index.data(Qt::DecorationRole).value<QIcon>().isNull();
+            if (hasIcon)
+                doc.setTextWidth(r.width() - 25);
+            else
+                doc.setTextWidth(r.width());
+        }
+
+        // draw text
+        painter->translate(option.rect.x(), option.rect.y());
+        // leave space for icon
+
+        if (!rtl)
+            painter->translate(25, 0);
+
+        doc.drawContents(painter);
+
+        painter->restore();
+    }
+
+public Q_SLOTS:
+    void setFilterString(const QString &text)
+    {
+        m_filterString = text;
+    }
+
+private:
+    QString m_filterString;
+};
+
+class ShortcutStyleDelegate : public QStyledItemDelegate
+{
+public:
+    ShortcutStyleDelegate(QObject *parent = nullptr)
+        : QStyledItemDelegate(parent)
+    {
+    }
+
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override
+    {
+        QStyleOptionViewItem options = option;
+        initStyleOption(&options, index);
+
+        QTextDocument doc;
+
+        const auto strs = index.data().toString();
+        doc.setDocumentMargin(2);
+        doc.setHtml(strs);
+
+        painter->save();
+
+        // paint background
+        if (option.state & QStyle::State_Selected) {
+            painter->fillRect(option.rect, option.palette.highlight());
+        } else {
+            painter->fillRect(option.rect, option.palette.base());
+        }
+
+        options.text = QString(); // clear old text
+        options.widget->style()->drawControl(QStyle::CE_ItemViewItem, &options, painter, options.widget);
+
+        if (!strs.isEmpty()) {
+            // collect button-style pixmaps
+            QVector<QPair<QRect, QString>> btnRects;
+            auto list = strs.split(QLatin1Char('+'));
+            for (auto text : list) {
+                auto r = option.fontMetrics.boundingRect(text);
+                r.setWidth(r.width() + 8);
+                r.setHeight(r.height() + 4);
+                btnRects.append({r, text});
+            }
+
+            auto plusRect = option.fontMetrics.boundingRect(QLatin1Char('+'));
+
+            // draw them
+            int dx = option.rect.x();
+            int y = option.rect.y();
+            int py = option.rect.y() + plusRect.height() / 2;
+            int total = btnRects.size();
+            int i = 0;
+            painter->setRenderHint(QPainter::Antialiasing); // :)
+            for (const auto& pxm : btnRects) {
+                // draw rounded rect shadown
+                painter->setPen(Qt::NoPen);
+                QRect r(dx, y, pxm.first.width(), pxm.first.height());
+                auto shadow = r.translated(0, 1);
+
+                painter->setBrush(option.palette.shadow());
+                painter->drawRoundedRect(shadow, 3, 3);
+
+                // draw rounded rect itself
+                painter->setBrush(option.palette.button());
+                painter->drawRoundedRect(r, 3, 3);
+
+                // draw text inside rounded rect
+                painter->setPen(option.palette.buttonText().color());
+                painter->drawText(r, Qt::AlignCenter, pxm.second);
+
+                // draw '+'
+                if (i + 1 < total) {
+                    dx += pxm.first.width() + 8;
+                    painter->drawText(QPoint(dx, py + (pxm.first.height() / 2)), QStringLiteral("+"));
+                    dx += plusRect.width() + 8;
+                }
+                i++;
+            }
+        }
+
+        painter->restore();
+    }
+};
+
+CommandBar::CommandBar(QWidget *parent)
+    : QMenu(parent)
+{
+    QVBoxLayout *layout = new QVBoxLayout();
+    layout->setSpacing(0);
+    layout->setContentsMargins(4, 4, 4, 4);
+    setLayout(layout);
+
+    m_lineEdit = new QLineEdit(this);
+    setFocusProxy(m_lineEdit);
+
+    layout->addWidget(m_lineEdit);
+
+    m_treeView = new QTreeView();
+    layout->addWidget(m_treeView, 1);
+    m_treeView->setTextElideMode(Qt::ElideLeft);
+    m_treeView->setUniformRowHeights(true);
+
+    m_model = new CommandModel(this);
+
+    CommandBarStyleDelegate* delegate = new CommandBarStyleDelegate(this);
+    ShortcutStyleDelegate* del = new ShortcutStyleDelegate(this);
+    m_treeView->setItemDelegateForColumn(0, delegate);
+    m_treeView->setItemDelegateForColumn(1, del);
+
+    m_proxyModel = new CommandBarFilterModel(this);
+    m_proxyModel->setFilterRole(Qt::DisplayRole);
+    m_proxyModel->setSortRole(CommandModel::Score);
+    m_proxyModel->setFilterKeyColumn(0);
+
+    connect(m_lineEdit, &QLineEdit::returnPressed, this, &CommandBar::slotReturnPressed);
+    connect(m_lineEdit, &QLineEdit::textChanged, m_proxyModel, &CommandBarFilterModel::setFilterString);
+    connect(m_lineEdit, &QLineEdit::textChanged, delegate, &CommandBarStyleDelegate::setFilterString);
+    connect(m_lineEdit, &QLineEdit::textChanged, this, [this](){
+        m_treeView->viewport()->update();
+        reselectFirst();
+    });
+    connect(m_treeView, &QTreeView::clicked, this, &CommandBar::slotReturnPressed);
+
+    m_proxyModel->setSourceModel(m_model);
+    m_treeView->setSortingEnabled(true);
+    m_treeView->setModel(m_proxyModel);
+
+    m_treeView->installEventFilter(this);
+    m_lineEdit->installEventFilter(this);
+
+    m_treeView->setHeaderHidden(true);
+    m_treeView->setRootIsDecorated(false);
+    m_treeView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_treeView->setSelectionMode(QTreeView::SingleSelection);
+
+    setHidden(true);
+}
+
+void CommandBar::updateBar(const QVector<QPair<QString, QList<QAction *> > > &actions)
+{
+    QVector<QPair<QString, QAction*>> actionList;
+    for (auto act : actions) {
+        for (const auto action : act.second) {
+            actionList.append({act.first, action});
+        }
+    }
+
+    m_model->refresh(std::move(actionList));
+    reselectFirst();
+
+    updateViewGeometry();
+    show();
+    setFocus();
+}
+
+bool CommandBar::eventFilter(QObject *obj, QEvent *event)
+{
+    // catch key presses + shortcut overrides to allow to have ESC as application wide shortcut, too, see bug 409856
+    if (event->type() == QEvent::KeyPress || event->type() == QEvent::ShortcutOverride) {
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        if (obj == m_lineEdit) {
+            const bool forward2list = (keyEvent->key() == Qt::Key_Up) || (keyEvent->key() == Qt::Key_Down) || (keyEvent->key() == Qt::Key_PageUp) || (keyEvent->key() == Qt::Key_PageDown);
+            if (forward2list) {
+                QCoreApplication::sendEvent(m_treeView, event);
+                return true;
+            }
+
+            if (keyEvent->key() == Qt::Key_Escape) {
+                m_lineEdit->clear();
+                keyEvent->accept();
+                hide();
+                return true;
+            }
+        } else {
+            const bool forward2input = (keyEvent->key() != Qt::Key_Up) && (keyEvent->key() != Qt::Key_Down) && (keyEvent->key() != Qt::Key_PageUp) && (keyEvent->key() != Qt::Key_PageDown) && (keyEvent->key() != Qt::Key_Tab) &&
+                (keyEvent->key() != Qt::Key_Backtab);
+            if (forward2input) {
+                QCoreApplication::sendEvent(m_lineEdit, event);
+                return true;
+            }
+        }
+    }
+
+    // hide on focus out, if neither input field nor list have focus!
+    else if (event->type() == QEvent::FocusOut && !(m_lineEdit->hasFocus() || m_treeView->hasFocus())) {
+        m_lineEdit->clear();
+        hide();
+        return true;
+    }
+
+    return QWidget::eventFilter(obj, event);
+}
+
+void CommandBar::slotReturnPressed()
+{
+    auto act = m_proxyModel->data(m_treeView->currentIndex(), Qt::UserRole).value<QAction*>();
+    if (act) {
+        // if the action is a menu, we take all its actions
+        // and reload our dialog with these instead.
+        if (auto menu = act->menu()) {
+            auto menuActions = menu->actions();
+            QVector<QPair<QString, QAction*>> list;
+            list.reserve(menuActions.size());
+
+            // if there are no actions, trigger load actions
+            // this happens with some menus that are loaded on demand
+            if (menuActions.size() == 0) {
+                Q_EMIT menu->aboutToShow();
+                menuActions = menu->actions();
+            }
+
+            for (auto menuAction : menuActions) {
+                if (menuAction) {
+                    list.append({Utils::Misc::removeAcceleratorMarker(act->text()), menuAction});
+                }
+            }
+            m_model->refresh(list);
+            m_lineEdit->clear();
+            return;
+        } else {
+            act->trigger();
+        }
+    }
+    m_lineEdit->clear();
+    hide();
+}
+
+void CommandBar::reselectFirst()
+{
+    QModelIndex index = m_proxyModel->index(0, 0);
+    m_treeView->setCurrentIndex(index);
+}
+
+void CommandBar::updateViewGeometry()
+{
+    m_treeView->resizeColumnToContents(0);
+    m_treeView->resizeColumnToContents(1);
+
+    const QSize centralSize = parentWidget()->size();
+
+    // width: 2.4 of editor, height: 1/2 of editor
+    const QSize viewMaxSize(centralSize.width() / 2.4, centralSize.height() / 2);
+
+    // Position should be central over window
+    const int xPos = std::max(0, (centralSize.width() - viewMaxSize.width()) / 2);
+    const int yPos = std::max(0, (centralSize.height() - viewMaxSize.height()) * 1 / 4);
+
+    const QPoint p(xPos, yPos);
+    move(p + parentWidget()->pos());
+
+    this->setFixedSize(viewMaxSize);
+}

--- a/src/dialogs/commandbar.cpp
+++ b/src/dialogs/commandbar.cpp
@@ -271,7 +271,7 @@ void CommandBar::updateBar(const QVector<QPair<QString, QList<QAction *> > > &ac
 {
     QVector<QPair<QString, QAction*>> actionList;
     for (auto act : actions) {
-        for (const auto action : act.second) {
+        for (const auto action : Utils::asConst(act.second)) {
             actionList.append({act.first, action});
         }
     }
@@ -340,7 +340,7 @@ void CommandBar::slotReturnPressed()
                 menuActions = menu->actions();
             }
 
-            for (auto menuAction : menuActions) {
+            for (auto menuAction : Utils::asConst(menuActions)) {
                 if (menuAction) {
                     list.append({Utils::Misc::removeAcceleratorMarker(act->text()), menuAction});
                 }

--- a/src/dialogs/commandbar.cpp
+++ b/src/dialogs/commandbar.cpp
@@ -46,8 +46,13 @@ protected:
 
         int score = 0;
         const auto idx = sourceModel()->index(sourceRow, 0, sourceParent);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
         const auto actionName = idx.data().toString().splitRef(QLatin1Char(':')).at(1);
         const bool res = fts::fuzzy_match_sequential(m_pattern, actionName, score);
+#else
+        const auto actionName = idx.data().toString().split(QLatin1Char(':')).at(1);
+        const bool res = fts::fuzzy_match_sequential(m_pattern, actionName, score);
+#endif
         sourceModel()->setData(idx, score, CommandModel::Score);
         return res;
     }

--- a/src/dialogs/commandbar.h
+++ b/src/dialogs/commandbar.h
@@ -1,0 +1,36 @@
+#ifndef COMMANDBAR_H
+#define COMMANDBAR_H
+
+#include <QMenu>
+
+class QMenuBar;
+class QTreeView;
+class CommandModel;
+class CommandBarFilterModel;
+class QLineEdit;
+
+class CommandBar : public QMenu
+{
+    Q_OBJECT
+public:
+    explicit CommandBar(QWidget *parent = nullptr);
+
+    void updateBar(const QVector<QPair<QString, QList<QAction*>>>& actions);
+
+    void updateViewGeometry();
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
+private Q_SLOTS:
+    void slotReturnPressed();
+    void reselectFirst();
+
+private:
+    QTreeView* m_treeView;
+    QLineEdit* m_lineEdit;
+    CommandModel* m_model;
+    CommandBarFilterModel* m_proxyModel;
+};
+
+#endif // COMMANDBAR_H

--- a/src/libraries/fuzzy/fts_fuzzy_match.h
+++ b/src/libraries/fuzzy/fts_fuzzy_match.h
@@ -13,7 +13,7 @@
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 using StringType = QStringView;
 #else
-using StringType = QStringRef;
+using StringType = QString;
 #endif
 
 /**

--- a/src/libraries/fuzzy/fts_fuzzy_match.h
+++ b/src/libraries/fuzzy/fts_fuzzy_match.h
@@ -13,7 +13,7 @@
 #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
 using StringType = QStringView;
 #else
-using StringType = QString;
+using StringType = QStringRef;
 #endif
 
 /**

--- a/src/libraries/fuzzy/fts_fuzzy_match.h
+++ b/src/libraries/fuzzy/fts_fuzzy_match.h
@@ -1,0 +1,278 @@
+/*
+    SPDX-FileCopyrightText: 2017 Forrest Smith
+    SPDX-FileCopyrightText: 2020 Waqar Ahmed
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+*/
+
+#ifndef KFTS_FUZZY_MATCH_H
+#define KFTS_FUZZY_MATCH_H
+
+#include <QString>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+using StringType = QStringView;
+#else
+using StringType = QString;
+#endif
+
+/**
+ * This is based on https://github.com/forrestthewoods/lib_fts/blob/master/code/fts_fuzzy_match.h
+ * with modifications for Qt
+ *
+ * Dont include this file in a header file, please :)
+ */
+
+namespace fts
+{
+/**
+ * @brief simple fuzzy matching of chars in @a pattern with chars in @a str sequentially
+ */
+Q_DECL_UNUSED static bool fuzzy_match_simple(const StringType pattern, const StringType str);
+
+/**
+ * @brief This should be the main function you should use. @a outscore is the score
+ * of this match and should be used to sort the results later. Without sorting of the
+ * results this function won't be as effective.
+ */
+Q_DECL_UNUSED static bool fuzzy_match(const StringType pattern, const StringType str, int &outScore);
+Q_DECL_UNUSED static bool fuzzy_match(const StringType pattern, const StringType str, int &outScore, uint8_t *matches, int maxMatches);
+
+/**
+ * @brief This is a special case function which doesn't score separator matches higher than sequential matches.
+ * This is currently used in Kate's command bar where the string items are usually space separated names.
+ */
+Q_DECL_UNUSED static bool fuzzy_match_sequential(const StringType pattern, const StringType str, int &outScore);
+/**
+ * @brief get string for display in treeview / listview. This should be used from style delegate.
+ * For example: with @a pattern = "kate", @a str = "kateapp" and @htmlTag = "<b>
+ * the output will be <b>k</b><b>a</b><b>t</b><b>e</b>app which will be visible to user as
+ * <b>kate</b>app.
+ *
+ * TODO: improve this so that we don't have to put html tags on every char probably using some kind
+ * of interval container
+ */
+Q_DECL_UNUSED static QString to_fuzzy_matched_display_string(const StringType pattern, QString &str, const QString &htmlTag, const QString &htmlTagClose);
+}
+
+namespace fts
+{
+// Forward declarations for "private" implementation
+namespace fuzzy_internal
+{
+static bool fuzzy_match_recursive(StringType::const_iterator pattern,
+                                  StringType::const_iterator str,
+                                  int &outScore,
+                                  const StringType::const_iterator strBegin,
+                                  const StringType::const_iterator strEnd,
+                                  const StringType::const_iterator patternEnd,
+                                  uint8_t const *srcMatches,
+                                  uint8_t *newMatches,
+                                  int maxMatches,
+                                  int nextMatch,
+                                  int &recursionCount,
+                                  int seqBonus = 15);
+}
+
+// Public interface
+static bool fuzzy_match_simple(const StringType pattern, const StringType str)
+{
+    auto patternIt = pattern.cbegin();
+    for (auto strIt = str.cbegin(); strIt != str.cend() && patternIt != pattern.cend(); ++strIt) {
+        if (strIt->toLower() == patternIt->toLower())
+            ++patternIt;
+    }
+    return patternIt == pattern.cend();
+}
+
+static bool fuzzy_match(const StringType pattern, const StringType str, int &outScore)
+{
+    uint8_t matches[256];
+    return fuzzy_match(pattern, str, outScore, matches, sizeof(matches));
+}
+
+static bool fuzzy_match(const StringType pattern, const StringType str, int &outScore, uint8_t *matches, int maxMatches)
+{
+    int recursionCount = 0;
+
+    auto strIt = str.cbegin();
+    auto patternIt = pattern.cbegin();
+    const auto patternEnd = pattern.cend();
+    const auto strEnd = str.cend();
+
+    return fuzzy_internal::fuzzy_match_recursive(patternIt, strIt, outScore, strIt, strEnd, patternEnd, nullptr, matches, maxMatches, 0, recursionCount);
+}
+
+static bool fuzzy_match_sequential(const StringType pattern, const StringType str, int &outScore)
+{
+    int recursionCount = 0;
+    uint8_t matches[256];
+    auto maxMatches = sizeof(matches);
+    auto strIt = str.cbegin();
+    auto patternIt = pattern.cbegin();
+    const auto patternEnd = pattern.cend();
+    const auto strEnd = str.cend();
+
+    return fuzzy_internal::fuzzy_match_recursive(patternIt, strIt, outScore, strIt, strEnd, patternEnd, nullptr, matches, maxMatches, 0, recursionCount, 40);
+}
+
+// Private implementation
+static bool fuzzy_internal::fuzzy_match_recursive(StringType::const_iterator pattern,
+                                                  StringType::const_iterator str,
+                                                  int &outScore,
+                                                  const StringType::const_iterator strBegin,
+                                                  const StringType::const_iterator strEnd,
+                                                  const StringType::const_iterator patternEnd,
+                                                  const uint8_t *srcMatches,
+                                                  uint8_t *matches,
+                                                  int maxMatches,
+                                                  int nextMatch,
+                                                  int &recursionCount,
+                                                  int seqBonus)
+{
+    // Count recursions
+    static constexpr int recursionLimit = 10;
+    ++recursionCount;
+    if (recursionCount >= recursionLimit)
+        return false;
+
+    // Detect end of strings
+    if (pattern == patternEnd || str == strEnd)
+        return false;
+
+    // Recursion params
+    bool recursiveMatch = false;
+    uint8_t bestRecursiveMatches[256];
+    int bestRecursiveScore = 0;
+
+    // Loop through pattern and str looking for a match
+    bool first_match = true;
+    while (pattern != patternEnd && str != strEnd) {
+        // Found match
+        if (pattern->toLower() == str->toLower()) {
+            // Supplied matches buffer was too short
+            if (nextMatch >= maxMatches)
+                return false;
+
+            // "Copy-on-Write" srcMatches into matches
+            if (first_match && srcMatches) {
+                memcpy(matches, srcMatches, nextMatch);
+                first_match = false;
+            }
+
+            // Recursive call that "skips" this match
+            uint8_t recursiveMatches[256];
+            int recursiveScore;
+            auto strNextChar = std::next(str);
+            if (fuzzy_match_recursive(pattern, strNextChar, recursiveScore, strBegin, strEnd, patternEnd, matches, recursiveMatches, sizeof(recursiveMatches), nextMatch, recursionCount)) {
+                // Pick best recursive score
+                if (!recursiveMatch || recursiveScore > bestRecursiveScore) {
+                    memcpy(bestRecursiveMatches, recursiveMatches, 256);
+                    bestRecursiveScore = recursiveScore;
+                }
+                recursiveMatch = true;
+            }
+
+            // Advance
+            matches[nextMatch++] = (uint8_t)(std::distance(strBegin, str));
+            ++pattern;
+        }
+        ++str;
+    }
+
+    // Determine if full pattern was matched
+    bool matched = pattern == patternEnd ? true : false;
+
+    // Calculate score
+    if (matched) {
+        int sequential_bonus = seqBonus; // bonus for adjacent matches
+        static constexpr int separator_bonus = 30; // bonus if match occurs after a separator
+        static constexpr int camel_bonus = 30; // bonus if match is uppercase and prev is lower
+        static constexpr int first_letter_bonus = 15; // bonus if the first letter is matched
+
+        static constexpr int leading_letter_penalty = -5; // penalty applied for every letter in str before the first match
+        static constexpr int max_leading_letter_penalty = -15; // maximum penalty for leading letters
+        static constexpr int unmatched_letter_penalty = -1; // penalty for every letter that doesn't matter
+
+        // Iterate str to end
+        while (str != strEnd)
+            ++str;
+
+        // Initialize score
+        outScore = 100;
+
+        // Apply leading letter penalty
+        int penalty = leading_letter_penalty * matches[0];
+        if (penalty < max_leading_letter_penalty)
+            penalty = max_leading_letter_penalty;
+        outScore += penalty;
+
+        // Apply unmatched penalty
+        const int unmatched = (int)(std::distance(strBegin, str)) - nextMatch;
+        outScore += unmatched_letter_penalty * unmatched;
+
+        // Apply ordering bonuses
+        for (int i = 0; i < nextMatch; ++i) {
+            uint8_t currIdx = matches[i];
+
+            if (i > 0) {
+                uint8_t prevIdx = matches[i - 1];
+
+                // Sequential
+                if (currIdx == (prevIdx + 1))
+                    outScore += sequential_bonus;
+            }
+
+            // Check for bonuses based on neighbor character value
+            if (currIdx > 0) {
+                // Camel case
+                QChar neighbor = *(strBegin + currIdx - 1);
+                QChar curr = *(strBegin + currIdx);
+                if (neighbor.isLower() && curr.isUpper())
+                    outScore += camel_bonus;
+
+                // Separator
+                bool neighborSeparator = neighbor == QLatin1Char('_') || neighbor == QLatin1Char(' ');
+                if (neighborSeparator)
+                    outScore += separator_bonus;
+            } else {
+                // First letter
+                outScore += first_letter_bonus;
+            }
+        }
+    }
+
+    // Return best result
+    if (recursiveMatch && (!matched || bestRecursiveScore > outScore)) {
+        // Recursive score is better than "this"
+        memcpy(matches, bestRecursiveMatches, maxMatches);
+        outScore = bestRecursiveScore;
+        return true;
+    } else if (matched) {
+        // "this" score is better than recursive
+        return true;
+    } else {
+        // no match
+        return false;
+    }
+}
+
+static QString to_fuzzy_matched_display_string(const StringType pattern, QString &str, const QString &htmlTag, const QString &htmlTagClose)
+{
+    /**
+     * FIXME Don't do so many appends. Instead consider using some interval based solution to wrap a range
+     * of text with the html <tag></tag>
+     */
+    int j = 0;
+    for (int i = 0; i < str.size() && j < pattern.size(); ++i) {
+        if (str.at(i).toLower() == pattern.at(j).toLower()) {
+            str.replace(i, 1, htmlTag + str.at(i) + htmlTagClose);
+            i += htmlTag.size() + htmlTagClose.size();
+            ++j;
+        }
+    }
+    return str;
+}
+} // namespace kfts
+
+#endif // KFTS_FUZZY_MATCH_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -114,6 +114,7 @@
 #include "ui_mainwindow.h"
 #include "version.h"
 #include "widgets/qownnotesmarkdowntextedit.h"
+#include "dialogs/commandbar.h"
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent), ui(new Ui::MainWindow) {
@@ -561,6 +562,8 @@ MainWindow::MainWindow(QWidget *parent)
             &MainWindow::on_action_Quit_triggered);
 
     automaticScriptUpdateCheck();
+
+    _commandBar = new CommandBar(this);
 }
 
 /**
@@ -11760,6 +11763,7 @@ void MainWindow::on_actionShow_all_panels_triggered() {
  * Opens the find action dialog
  */
 void MainWindow::on_actionFind_action_triggered() {
+#if 0
     if (_actionDialog == Q_NULLPTR) {
         _actionDialog = new ActionDialog(ui->menuBar, this);
     } else {
@@ -11769,6 +11773,21 @@ void MainWindow::on_actionFind_action_triggered() {
     _actionDialog->show();
     _actionDialog->activateWindow();
     _actionDialog->raise();
+#endif
+    auto menuBar = this->menuBar();
+    const auto menus = menuBar->actions();
+
+    QVector<QPair<QString, QList<QAction*>>> actions;
+    for (auto subMenu : menus) {
+        if (auto menu = subMenu->menu()) {
+            const auto menuActions = menu->actions();
+            actions.append({menu->title(), menuActions});
+        }
+    }
+
+    _commandBar->updateBar(actions);
+    _commandBar->show();
+    _commandBar->setFocus();
 }
 
 /**

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -70,6 +70,7 @@ class UpdateService;
 class FakeVimHandler;
 class WebSocketServerService;
 class QOwnNotesMarkdownTextEdit;
+class CommandBar;
 
 // forward declaration because of "xxx does not name a type"
 class TodoDialog;
@@ -767,6 +768,7 @@ private:
     bool _scriptUpdateFound = false;
     bool _isMaximizedBeforeFullScreen = false;
     bool _isMinimizedBeforeFullScreen = false;
+    CommandBar* _commandBar;
 
     void createSystemTrayIcon();
 

--- a/src/models/commandmodel.cpp
+++ b/src/models/commandmodel.cpp
@@ -1,0 +1,66 @@
+/*
+    SPDX-FileCopyrightText: 2021 Waqar Ahmed <waqar.17a@gmail.com>
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+*/
+#include "commandmodel.h"
+
+#include <QAction>
+#include <QDebug>
+
+#include "utils/misc.h"
+
+CommandModel::CommandModel(QObject *parent)
+    : QAbstractTableModel(parent)
+{
+}
+
+void CommandModel::refresh(QVector<QPair<QString, QAction*>> actionList)
+{
+    QVector<Item> temp;
+    temp.reserve(actionList.size());
+    for (auto action : actionList) {
+        temp.push_back({action.first, action.second, 0});
+    }
+
+    beginResetModel();
+    m_rows = std::move(temp);
+    endResetModel();
+}
+
+QVariant CommandModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return {};
+
+    auto entry = m_rows[index.row()];
+    int col = index.column();
+
+    switch (role)
+    {
+    case Qt::DisplayRole:
+        if (col == 0)
+            return QString(Utils::Misc::removeAcceleratorMarker(entry.component) + QStringLiteral(": ") + Utils::Misc::removeAcceleratorMarker(entry.action->text()));
+        else
+            return entry.action->shortcut().toString();
+    case Qt::DecorationRole:
+        if (col == 0)
+            return entry.action->icon();
+        break;
+    case Qt::TextAlignmentRole:
+        if (col == 0)
+            return Qt::AlignLeft;
+        else
+            return Qt::AlignRight;
+    case Qt::UserRole:
+    {
+        QVariant v;
+        v.setValue(entry.action);
+        return v;
+    }
+    case Role::Score:
+        return entry.score;
+    }
+
+    return {};
+}

--- a/src/models/commandmodel.h
+++ b/src/models/commandmodel.h
@@ -1,0 +1,63 @@
+/*
+    SPDX-FileCopyrightText: 2021 Waqar Ahmed <waqar.17a@gmail.com>
+
+    SPDX-License-Identifier: LGPL-2.0-or-later
+*/
+#ifndef COMMANDMODEL_H
+#define COMMANDMODEL_H
+
+#include <QAbstractTableModel>
+#include <QVector>
+
+class QAction;
+
+class CommandModel : public QAbstractTableModel
+{
+    struct Item
+    {
+        QString component;
+        QAction* action;
+        int score;
+    };
+
+    Q_OBJECT
+public:
+    CommandModel(QObject* parent = nullptr);
+
+    enum Role { Score = Qt::UserRole + 1 };
+
+    void refresh(QVector<QPair<QString, QAction*>> actionList);
+
+    int rowCount(const QModelIndex & parent = QModelIndex()) const override
+    {
+        if (parent.isValid()) {
+            return 0;
+        }
+        return m_rows.size();
+    }
+
+    int columnCount(const QModelIndex & parent = QModelIndex()) const override
+    {
+        Q_UNUSED(parent);
+        return 2;
+    }
+
+    bool setData(const QModelIndex &index, const QVariant &value, int role) override
+    {
+        if (!index.isValid())
+            return false;
+        if (role == Role::Score) {
+            auto row = index.row();
+            m_rows[row].score = value.toInt();
+        }
+        return QAbstractTableModel::setData(index, value, role);
+    }
+
+    QVariant data(const QModelIndex &index, int role) const override;
+
+private:
+    QVector<Item> m_rows;
+
+};
+
+#endif // COMMANDMODEL_H

--- a/src/utils/misc.cpp
+++ b/src/utils/misc.cpp
@@ -2115,3 +2115,91 @@ bool Utils::Misc::fileExists(const QString& path) {
     const QFileInfo fileInfo(file);
     return file.exists() && fileInfo.isFile() && fileInfo.isReadable();
 }
+
+static QString removeReducedCJKAccMark(const QString &label, int pos)
+{
+    if (pos > 0 && pos + 1 < label.length()
+            && label[pos - 1] == QLatin1Char('(') && label[pos + 1] == QLatin1Char(')')
+            && label[pos].isLetterOrNumber()) {
+        // Check if at start or end, ignoring non-alphanumerics.
+        int len = label.length();
+        int p1 = pos - 2;
+        while (p1 >= 0 && !label[p1].isLetterOrNumber()) {
+            --p1;
+        }
+        ++p1;
+        int p2 = pos + 2;
+        while (p2 < len && !label[p2].isLetterOrNumber()) {
+            ++p2;
+        }
+        --p2;
+
+        if (p1 == 0) {
+            return label.leftRef(pos - 1) + label.midRef(p2 + 1);
+        } else if (p2 + 1 == len) {
+            return label.leftRef(p1) + label.midRef(pos + 2);
+        }
+    }
+    return label;
+}
+
+/**
+ * @brief Removes accelarator markers from a label
+ *
+ * Taken from KDE's Ki18n library
+ */
+QString Utils::Misc::removeAcceleratorMarker(const QString &label_)
+{
+    QString label = label_;
+
+    int p = 0;
+    bool accmarkRemoved = false;
+    while (true) {
+        p = label.indexOf(QLatin1Char('&'), p);
+        if (p < 0 || p + 1 == label.length()) {
+            break;
+        }
+
+        if (label[p + 1].isLetterOrNumber()) {
+            // Valid accelerator.
+            label = QString(label.leftRef(p) + label.midRef(p + 1));
+
+            // May have been an accelerator in CJK-style "(&X)"
+            // at the start or end of text.
+            label = removeReducedCJKAccMark(label, p);
+
+            accmarkRemoved = true;
+        } else if (label[p + 1] == QLatin1Char('&')) {
+            // Escaped accelerator marker.
+            label = QString(label.leftRef(p) + label.midRef(p + 1));
+        }
+
+        ++p;
+    }
+
+    // If no marker was removed, and there are CJK characters in the label,
+    // also try to remove reduced CJK marker -- something may have removed
+    // ampersand beforehand.
+    if (!accmarkRemoved) {
+        bool hasCJK = false;
+        for (const QChar c : qAsConst(label)) {
+            if (c.unicode() >= 0x2e00) { // rough, but should be sufficient
+                hasCJK = true;
+                break;
+            }
+        }
+        if (hasCJK) {
+            p = 0;
+            while (true) {
+                p = label.indexOf(QLatin1Char('('), p);
+                if (p < 0) {
+                    break;
+                }
+                label = removeReducedCJKAccMark(label, p + 1);
+                ++p;
+            }
+        }
+    }
+
+    return label;
+}

--- a/src/utils/misc.cpp
+++ b/src/utils/misc.cpp
@@ -2135,9 +2135,9 @@ static QString removeReducedCJKAccMark(const QString &label, int pos)
         --p2;
 
         if (p1 == 0) {
-            return label.leftRef(pos - 1) + label.midRef(p2 + 1);
+            return label.left(pos - 1) + label.mid(p2 + 1);
         } else if (p2 + 1 == len) {
-            return label.leftRef(p1) + label.midRef(pos + 2);
+            return label.left(p1) + label.mid(pos + 2);
         }
     }
     return label;
@@ -2162,7 +2162,7 @@ QString Utils::Misc::removeAcceleratorMarker(const QString &label_)
 
         if (label[p + 1].isLetterOrNumber()) {
             // Valid accelerator.
-            label = QString(label.leftRef(p) + label.midRef(p + 1));
+            label = QString(label.left(p) + label.mid(p + 1));
 
             // May have been an accelerator in CJK-style "(&X)"
             // at the start or end of text.
@@ -2171,7 +2171,7 @@ QString Utils::Misc::removeAcceleratorMarker(const QString &label_)
             accmarkRemoved = true;
         } else if (label[p + 1] == QLatin1Char('&')) {
             // Escaped accelerator marker.
-            label = QString(label.leftRef(p) + label.midRef(p + 1));
+            label = QString(label.left(p) + label.mid(p + 1));
         }
 
         ++p;
@@ -2182,7 +2182,7 @@ QString Utils::Misc::removeAcceleratorMarker(const QString &label_)
     // ampersand beforehand.
     if (!accmarkRemoved) {
         bool hasCJK = false;
-        for (const QChar c : qAsConst(label)) {
+        for (const QChar c : asConst(label)) {
             if (c.unicode() >= 0x2e00) { // rough, but should be sufficient
                 hasCJK = true;
                 break;

--- a/src/utils/misc.h
+++ b/src/utils/misc.h
@@ -142,6 +142,7 @@ bool isPreviewUseEditorStyles();
 QString previewFontString();
 QString previewCodeFontString();
 bool fileExists(const QString &path);
+QString removeAcceleratorMarker(const QString &label_);
 }    // namespace Misc
 }    // namespace Utils
 


### PR DESCRIPTION
This change replaces the "find action" dialog with a more (imo) slick command bar. It has the option to fuzzy filter and navigate through submenus. 

Screenshot:

![image](https://user-images.githubusercontent.com/7696024/105515789-ef36fa80-5cf6-11eb-93c6-854067c5f081.png)

I haven't removed the code for "find action" yet so that if this gets tested and accepted we can take care of it later. For now it is just disabled. Most of the code is vanilla Qt with a couple of things taken from outside (removal of accelerator markers is taken from KDE and fuzzy match library is taken from Forrest Woods's lib_fts).
