### PR TITLE
Load all actions in command bar

### DIFF
--- a/src/dialogs/commandbar.cpp
+++ b/src/dialogs/commandbar.cpp
@@ -272,16 +272,9 @@ CommandBar::CommandBar(QWidget *parent)
     setHidden(true);
 }
 
-void CommandBar::updateBar(const QVector<QPair<QString, QList<QAction *> > > &actions)
+void CommandBar::updateBar(const QVector<QPair<QString, QAction *> > &actions)
 {
-    QVector<QPair<QString, QAction*>> actionList;
-    for (auto act : actions) {
-        for (const auto action : Utils::asConst(act.second)) {
-            actionList.append({act.first, action});
-        }
-    }
-
-    m_model->refresh(std::move(actionList));
+    m_model->refresh(actions);
     reselectFirst();
 
     updateViewGeometry();

--- a/src/dialogs/commandbar.h
+++ b/src/dialogs/commandbar.h
@@ -15,7 +15,7 @@ class CommandBar : public QMenu
 public:
     explicit CommandBar(QWidget *parent = nullptr);
 
-    void updateBar(const QVector<QPair<QString, QList<QAction*>>>& actions);
+    void updateBar(const QVector<QPair<QString, QAction*>>& actions);
 
     void updateViewGeometry();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11759,6 +11759,22 @@ void MainWindow::on_actionShow_all_panels_triggered() {
     filterNotes();
 }
 
+static void loadAllActions(QMenu* menu, QVector<QPair<QString, QAction*>>& outActions) {
+    if (!menu)
+        return;
+    const auto menuActions = menu->actions();
+    QVector<QPair<QString, QAction*>> actions;
+    actions.reserve(menuActions.size());
+    for (auto action : menuActions) {
+        if (auto submenu = action->menu()) {
+            loadAllActions(submenu, outActions);
+        } else {
+            if (!action->text().isEmpty())
+                outActions.append({menu->title(), action});
+        }
+    }
+}
+
 /**
  * Opens the find action dialog
  */
@@ -11777,11 +11793,10 @@ void MainWindow::on_actionFind_action_triggered() {
     auto menuBar = this->menuBar();
     const auto menus = menuBar->actions();
 
-    QVector<QPair<QString, QList<QAction*>>> actions;
+    QVector<QPair<QString, QAction*>> actions;
     for (auto subMenu : menus) {
         if (auto menu = subMenu->menu()) {
-            const auto menuActions = menu->actions();
-            actions.append({menu->title(), menuActions});
+            loadAllActions(menu, actions);
         }
     }
 


### PR DESCRIPTION
All actions will be visible now.

It has the same amount of actions as the previous widget as far as I can see. Toolbar actions are redundant so loading them will only lead to duplication. Actions for invoking scripts / context menu actions / any other can be added as an addition