### PR TITLE
Restore workspace after window resize

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11533,7 +11533,7 @@ void MainWindow::setCurrentWorkspace(const QString &uuid) {
     settings.setValue(QStringLiteral("currentWorkspace"), uuid);
 
     // restore the new workspace
-    restoreCurrentWorkspace();
+    QTimer::singleShot(0, this, SLOT(restoreCurrentWorkspace()));
 
     // update the menu and combo box (but don't rebuild it)
     updateWorkspaceLists(false);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -513,7 +513,7 @@ class MainWindow : public QMainWindow {
 
     void on_actionShow_all_panels_triggered();
 
-    void restoreCurrentWorkspace();
+    Q_SLOT void restoreCurrentWorkspace();
 
     void togglePanelVisibility(const QString &objectName);
 


### PR DESCRIPTION
This is my QON workflow:
* I use it in a small window, alongside other applications, for quickly looking through my notes; I do this in a 'Preview only' workspace because I don't do any editing at this point
* When I want to edit something, I maximize the window, and this will switch to the 'Edit' workspace (using the 'Dynamic workspace' plugin).

The problem is that the window state is applied before the resize, so after the resize the docks will not have the sizes that I previously set:
https://www.youtube.com/watch?v=0y25bzaL2nw

In order to preserve the dock sizes, the window state must be applied after the resize:
https://www.youtube.com/watch?v=_bVFMDKUvkE




