### PR TITLE
Disable xmlpatterns and co. for Qt-6

### DIFF
--- a/src/dialogs/attachmentdialog.cpp
+++ b/src/dialogs/attachmentdialog.cpp
@@ -88,7 +88,7 @@ void AttachmentDialog::on_downloadButton_clicked() {
     QUrl url(ui->fileEdit->text());
     QNetworkRequest networkRequest(url);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)) && (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute,
                                 true);
 #endif

--- a/src/dialogs/dictionarymanagerdialog.cpp
+++ b/src/dialogs/dictionarymanagerdialog.cpp
@@ -253,7 +253,7 @@ void DictionaryManagerDialog::on_downloadButton_clicked() {
 void DictionaryManagerDialog::downloadFile(const QString &url) {
     QNetworkRequest networkRequest(url);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)) && (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute,
                                 true);
 #endif

--- a/src/dialogs/evernoteimportdialog.h
+++ b/src/dialogs/evernoteimportdialog.h
@@ -34,13 +34,11 @@ class EvernoteImportDialog : public MasterDialog {
     Ui::EvernoteImportDialog *ui;
     int _importCount;
 
-    void importNotes(const QString &data);
+    void setupMetaDataTreeWidgetItems();
 
-    int countNotes(const QString &data);
+    void storeMetaDataTreeWidgetItemsCheckedState();
 
     void initNoteCount(const QString &data);
-
-    QString importImages(const Note &note, QString content, QXmlQuery query);
 
     QString getMarkdownForMediaFileData(Note note,
                                         const MediaFileData &mediaFileData);
@@ -48,20 +46,26 @@ class EvernoteImportDialog : public MasterDialog {
     QString getMarkdownForAttachmentFileData(
         Note note, const MediaFileData &mediaFileData);
 
+    QTreeWidgetItem *addMetaDataTreeWidgetItem(
+        const QString &name, const QString &attributeName = QString(),
+        QTreeWidgetItem *parentItem = nullptr);
+
+    bool isMetaDataChecked();
+
+
+    /** These require xml patterns **/
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    void importNotes(const QString &data);
+
+    int countNotes(const QString &data);
+
+    QString importImages(const Note &note, QString content, QXmlQuery query);
+
     void tagNote(QXmlQuery &query, Note &note);
 
     QString importAttachments(const Note &note, QString content,
                               QXmlQuery query);
 
-    QTreeWidgetItem *addMetaDataTreeWidgetItem(
-        const QString &name, const QString &attributeName = QString(),
-        QTreeWidgetItem *parentItem = nullptr);
-
-    void setupMetaDataTreeWidgetItems();
-
-    bool isMetaDataChecked();
-
     QString generateMetaDataMarkdown(QXmlQuery query);
-
-    void storeMetaDataTreeWidgetItemsCheckedState();
+#endif
 };

--- a/src/dialogs/scriptrepositorydialog.cpp
+++ b/src/dialogs/scriptrepositorydialog.cpp
@@ -120,7 +120,7 @@ void ScriptRepositoryDialog::searchScript(int page) {
     QNetworkRequest networkRequest(url);
     _page = page;
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)) && (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute,
                                 true);
 #endif
@@ -152,7 +152,7 @@ void ScriptRepositoryDialog::searchForUpdates() {
         QUrl url = script.repositoryInfoJsonUrl();
         QNetworkRequest networkRequest(url);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)) && (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute,
                                     true);
 #endif
@@ -242,7 +242,7 @@ void ScriptRepositoryDialog::parseCodeSearchReply(const QByteArray &arr) {
         QUrl url(_rawContentUrlPrefix + path);
         QNetworkRequest networkRequest(url);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)) && (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
         networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute,
                                     true);
 #endif

--- a/src/dialogs/updatedialog.cpp
+++ b/src/dialogs/updatedialog.cpp
@@ -183,7 +183,7 @@ void UpdateDialog::dialogButtonClicked(QAbstractButton *button) {
             QUrl url(releaseUrl);
             QNetworkRequest networkRequest(url);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)) && (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
             // we really need redirects for GitHub urls!
             networkRequest.setAttribute(
                 QNetworkRequest::FollowRedirectsAttribute, true);

--- a/src/services/owncloudservice.cpp
+++ b/src/services/owncloudservice.cpp
@@ -2061,7 +2061,7 @@ bool OwnCloudService::updateICSDataOfCalendarItem(CalendarItem *calItem) {
     // 5 sec timeout for the request
     timer.start(5000);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)) && (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     r.setAttribute(QNetworkRequest::FollowRedirectsAttribute, true);
 #endif
 
@@ -2178,7 +2178,7 @@ QByteArray OwnCloudService::downloadNextcloudPreviewImage(const QString &path) {
     QNetworkRequest networkRequest = QNetworkRequest(url);
     addAuthHeader(&networkRequest);
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)) && (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     networkRequest.setAttribute(QNetworkRequest::FollowRedirectsAttribute,
                                 true);
 #endif

--- a/src/services/owncloudservice.cpp
+++ b/src/services/owncloudservice.cpp
@@ -23,8 +23,13 @@
 #include <QStringBuilder>
 #include <QTimer>
 #include <QUrlQuery>
-#include <QXmlQuery>
-#include <QXmlResultItems>
+
+// Disabled for Qt-6
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+    #include <QXmlQuery>
+    #include <QXmlResultItems>
+#endif
+
 
 #include "cryptoservice.h"
 #include "dialogs/serverbookmarksimportdialog.h"
@@ -1716,6 +1721,7 @@ void OwnCloudService::handleUpdateNoteShareReply(const QString &urlPart,
         return;
     }
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     //    qDebug() << __func__ << " - 'data': " << data;
 
     QRegularExpression re(QRegularExpression::escape(sharePath) %
@@ -1775,6 +1781,8 @@ void OwnCloudService::handleUpdateNoteShareReply(const QString &urlPart,
         shareDialog->updateDialog();
     }
 #endif
+
+#endif // QT_6_VERSION_CHECK
 }
 
 /**
@@ -1788,6 +1796,7 @@ void OwnCloudService::updateNoteShareStatusFromShare(QString &data) {
         return;
     }
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     QXmlQuery query;
     query.setFocus(data);
     query.setQuery(QStringLiteral("ocs/meta/status/text()"));
@@ -1807,6 +1816,7 @@ void OwnCloudService::updateNoteShareStatusFromShare(QString &data) {
 
     query.setQuery(QStringLiteral("ocs/data"));
     updateNoteShareStatus(query, true);
+#endif
 }
 
 /**
@@ -1820,6 +1830,7 @@ void OwnCloudService::updateNoteShareStatusFromFetchAll(QString &data) {
         return;
     }
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     QXmlQuery query;
     query.setFocus(data);
     query.setQuery(QStringLiteral("ocs/data/element"));
@@ -1829,8 +1840,10 @@ void OwnCloudService::updateNoteShareStatusFromFetchAll(QString &data) {
     }
 
     updateNoteShareStatus(query);
+#endif
 }
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
 void OwnCloudService::updateNoteShareStatus(QXmlQuery &query,
                                             bool updateShareDialog) {
     QXmlResultItems results;
@@ -1925,6 +1938,7 @@ void OwnCloudService::updateNoteShareStatus(QXmlQuery &query,
         }
     }
 }
+#endif
 
 void OwnCloudService::loadDirectory(QString &data) {
     QDomDocument doc;

--- a/src/services/owncloudservice.h
+++ b/src/services/owncloudservice.h
@@ -158,8 +158,11 @@ class OwnCloudService : public QObject {
 
     void handleNoteShareReply(QString &data);
 
+// Disabled till there is alternative in Qt6
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
     void updateNoteShareStatus(QXmlQuery &query,
                                bool updateShareDialog = false);
+#endif
 
     void handleUpdateNoteShareReply(const QString &urlPart,
                                     const QString &data);


### PR DESCRIPTION
Make QON compile on Qt-6

Changes done:

- We are not getting xmlpatterns. So, we need to use something else. For now xml-pattern code is disabled for Qt-6