### PR TITLE
Stop installing app icon in pixmaps location

### DIFF
--- a/build-systems/aur/PKGBUILD
+++ b/build-systems/aur/PKGBUILD
@@ -33,7 +33,6 @@ package() {
 
     # install visuals
     install -D -m644 PBE.QOwnNotes.desktop "${pkgdir}/usr/share/applications/PBE.QOwnNotes.desktop"
-    install -D -m644 "images/icons/128x128/apps/QOwnNotes.png" "${pkgdir}/usr/share/pixmaps/QOwnNotes.png"
     for format in {16x16,24x24,32x32,48x48,64x64,96x96,128x128,256x256,512x512}; do
         install -D -m644 "images/icons/${format}/apps/QOwnNotes.png" "${pkgdir}/usr/share/icons/hicolor/$format/apps/QOwnNotes.png"
     done

--- a/obs/PKGBUILD
+++ b/obs/PKGBUILD
@@ -30,7 +30,6 @@ package() {
 
     # install visuals
     install -D -m644 PBE.QOwnNotes.desktop "${pkgdir}/usr/share/applications/PBE.QOwnNotes.desktop"
-    install -D -m644 "images/icons/128x128/apps/QOwnNotes.png" "${pkgdir}/usr/share/pixmaps/QOwnNotes.png"
     for format in {16x16,24x24,32x32,48x48,64x64,96x96,128x128,256x256,512x512}; do
         install -D -m644 "images/icons/${format}/apps/QOwnNotes.png" "${pkgdir}/usr/share/icons/hicolor/$format/apps/QOwnNotes.png"
     done

--- a/src/debian/qownnotes.install
+++ b/src/debian/qownnotes.install
@@ -1,5 +1,4 @@
 PBE.QOwnNotes.desktop usr/share/applications
-images/icons/128x128/apps/QOwnNotes.png usr/share/pixmaps
 images/icons/16x16/apps/QOwnNotes.png usr/share/icons/hicolor/16x16/apps
 images/icons/24x24/apps/QOwnNotes.png usr/share/icons/hicolor/24x24/apps
 images/icons/32x32/apps/QOwnNotes.png usr/share/icons/hicolor/32x32/apps


### PR DESCRIPTION
The `/usr/share/pixmaps` location is considered a legacy location for application icons; since the application icons are already installed in the global XDG hicolor theme, then simply stop installing the 128px one in the legacy pixmaps location.