### PR TITLE
Update RPM (SUSE+Fedora) repository instructions

### DIFF
--- a/webpage/src/installation/fedora.md
+++ b/webpage/src/installation/fedora.md
@@ -2,10 +2,24 @@
 
 There are QOwnNotes repositories for **Fedora 28 and higher**.
 
-Run the following shell commands as root to trust the repository.
+## Actual install method :
+
+Run the following shell commands as root to add the repository.
 
 ```bash
-su -
+dnf config-manager --add-repo http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Fedora_\$releasever/
+
+dnf makecache
+dnf install qownotes
+```
+
+NOTE : You may need to accept the repo key before you can download from it
+
+## Legacy install method :
+
+If your Fedora version doesn't support the `config-manager` dnf plugin, run these commands as root :
+
+```bash
 rpm --import http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Fedora_34/repodata/repomd.xml.key
 ```
 

--- a/webpage/src/installation/opensuse.md
+++ b/webpage/src/installation/opensuse.md
@@ -6,13 +6,6 @@
 
 ## openSUSE 13.2
 
-Run the following shell commands as root to trust the repository.
-
-```bash
-su -
-rpm --import http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/openSUSE_13.2/repodata/repomd.xml.key
-```
-
 Run the following shell commands as root to add the repository and install QOwnNotes from there.
 
 ```bash
@@ -20,16 +13,10 @@ zypper addrepo -f http://download.opensuse.org/repositories/home:/pbek:/QOwnNote
 zypper refresh
 zypper install qownnotes
 ```
+
 [Direct Download](https://build.opensuse.org/package/binaries/home:pbek:QOwnNotes/desktop/openSUSE_13.2)
 
 ## openSUSE Leap 15.3
-
-Run the following shell commands as root to trust the repository.
-
-```bash
-su -
-rpm --import http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/openSUSE_Leap_15.3/repodata/repomd.xml.key
-```
 
 Run the following shell commands as root to add the repository and install QOwnNotes from there.
 
@@ -43,13 +30,6 @@ zypper install qownnotes
 
 ## openSUSE Leap 15.2
 
-Run the following shell commands as root to trust the repository.
-
-```bash
-su -
-rpm --import http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/openSUSE_Leap_15.2/repodata/repomd.xml.key
-```
-
 Run the following shell commands as root to add the repository and install QOwnNotes from there.
 
 ```bash
@@ -62,15 +42,6 @@ zypper install qownnotes
 
 ## openSUSE Leap 15.1
 
-Run the following shell commands as root to trust the repository.
-
-```bash
-su -
-rpm --import http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/openSUSE_Leap_15.1/repodata/repomd.xml.key
-```
-
-Run the following shell commands as root to add the repository and install QOwnNotes from there.
-
 ```bash
 zypper addrepo -f http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/openSUSE_Leap_15.1/home:pbek:QOwnNotes.repo
 zypper refresh
@@ -81,21 +52,14 @@ zypper install qownnotes
 
 ## openSUSE Leap 15.0
 
-Run the following shell commands as root to trust the repository.
-
-```bash
-su -
-rpm --import http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/openSUSE_Leap_15.0/repodata/repomd.xml.key
-```
-
-Run the following shell commands as 
-root to add the repository and install QOwnNotes from there.
+Run the following shell commands as root to add the repository and install QOwnNotes from there.
 
 ```bash
 zypper addrepo -f http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/openSUSE_Leap_15.0/home:pbek:QOwnNotes.repo
 zypper refresh
 zypper install qownnotes
 ```
+
 [Direct Download](https://build.opensuse.org/package/binaries/home:pbek:QOwnNotes/desktop/openSUSE_Leap_15.0)
 
 ## openSUSE Leap 42.3
@@ -157,13 +121,6 @@ zypper install qownnotes
 
 ## openSUSE Tumbleweed
 
-Run the following shell commands as root to trust the repository.
-
-```bash
-su -
-rpm --import http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/openSUSE_Tumbleweed/repodata/repomd.xml.key
-```
-
 Run the following shell commands as root to add the repository and install QOwnNotes from there.
 
 ```bash
@@ -177,13 +134,6 @@ zypper install qownnotes
 
 ## SLE 12 SP3 Backports
 
-Run the following shell commands as root to trust the repository.
-
-```bash
-su -
-rpm --import http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/SLE_12_SP3_Backports/repodata/repomd.xml.key
-```
-
 Run the following shell commands as root to add the repository and install QOwnNotes from there.
 
 ```bash
@@ -195,13 +145,6 @@ zypper install qownnotes
 [Direct Download](https://build.opensuse.org/package/binaries/home:pbek:QOwnNotes/desktop/SLE_12_SP3_Backports)
 
 ## SLE 15
-
-Run the following shell commands as root to trust the repository.
-
-```bash
-su -
-rpm --import http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/SLE_15/repodata/repomd.xml.key
-```
 
 Run the following shell commands as root to add the repository and install QOwnNotes from there.
 

--- a/webpage/src/installation/opensuse.md
+++ b/webpage/src/installation/opensuse.md
@@ -4,6 +4,32 @@
 
 <!-- <Content :page-key="getPageKey($site.pages, '/installation/ubuntu.md')" /> -->
 
+
+## On every openSUSE version
+
+You can install QOwnNotes using the [opi](https://github.com/openSUSE/opi) tool
+
+Run the following shell commands as root to install `opi` and install QOwnNotes from there.
+
+```bash
+zypper install opi
+```
+
+```bash
+opi qownnotes
+```
+
+::: warning
+This tool will query the entire OBS service so  
+Be sure to choose `qownnotes` and not `qownnotes-lang` if asked
+
+And check that the choosen repo is the official one **`home:pbek:QOwnNotes`** and not a third-party one
+:::
+
+::: tip
+You need to choose to keep the repo after installation to get updates
+:::
+
 ## openSUSE 13.2
 
 Run the following shell commands as root to add the repository and install QOwnNotes from there.


### PR DESCRIPTION
Deleted outdated lines, added dnf-config-manager method for Fedora

DNF includes a plugin to automatically add and negociate repos, including keys, added that method. Zypper has that feature too, which makes `rpm --import` redundent. You can also use `opi` (commit incoming) to install from the obs automatically on openSUSE
