### PR TITLE
Sharing feedback on YouTube

### DIFF
--- a/webpage/src/contributing/get-involved.md
+++ b/webpage/src/contributing/get-involved.md
@@ -15,3 +15,4 @@ The various ways to get involved with QOwnNotes
 - Report problems or share ideas for new features on the [QOwnNotes **GitHub issues** page](https://github.com/pbek/QOwnNotes/issues)
 - If you have made a great editor schema please also post it at the [**GitHub issues** page](https://github.com/pbek/QOwnNotes/issues)
 - Share your scripts at the [**QOwnNotes scripts** GitHub page](https://github.com/qownnotes/scripts)
+- You are most welcome to share **your experience with QOwnNotes** on your own YouTube channel, while you are also invited to share positive feedback by [sending audio/video/text to Amy](mailto:amydoralang@aol.de) for upload on our own YT channel [**QOwnNotes in a Nutshell**](https://www.youtube.com/channel/UC6Xpk_B1MFfvhBCsH_MrOEw/videos).


### PR DESCRIPTION
In reaction to comment in issue #2173 line 18 was changed into offering both options to upload on own YouTube or our YT channel and my name was added to send email to.