### PR TITLE
Improve performance when note has images

### DIFF
--- a/src/entities/note.h
+++ b/src/entities/note.h
@@ -18,7 +18,7 @@ class QSqlQuery;
 
 class Note {
    public:
-    explicit Note();
+    Note();
 
     int getId() const;
 

--- a/src/widgets/notepreviewwidget.h
+++ b/src/widgets/notepreviewwidget.h
@@ -44,6 +44,11 @@ class NotePreviewWidget : public QTextBrowser {
 
     void contextMenuEvent(QContextMenuEvent *event) override;
 
+    QVariant loadResource(int type, const QUrl& file) override;
+
+    bool lookupCache(const QString &key, QPixmap &pm);
+    void insertInCache(const QString &key, const QPixmap &pm);
+
    public slots:
     void hide();
 
@@ -52,4 +57,11 @@ class NotePreviewWidget : public QTextBrowser {
 
    private:
     QList<QMovie *> _movies;
+    QString _currentFile;
+
+    struct LargePixmap {
+        QString fileName;
+        QPixmap pixmap;
+    };
+    std::vector<LargePixmap> _largePixmapCache;
 };


### PR DESCRIPTION
This change massively improves performance for notes that have images.
It improves the load time of notes as well.

#2078