### PR TITLE
Use static QregularExpressions to improve performance

### DIFF
--- a/src/helpers/codetohtmlconverter.cpp
+++ b/src/helpers/codetohtmlconverter.cpp
@@ -519,7 +519,7 @@ QString CodeToHtmlConverter::xmlHighlighter(StringView input) const {
 
                 StringView tag = input.mid(i, found - i);
 
-                QRegularExpression re(R"(([a-zA-Z0-9]+(\s*=\s*"[^"]*")?))");
+                static const QRegularExpression re(R"(([a-zA-Z0-9]+(\s*=\s*"[^"]*")?))");
                 QRegularExpressionMatchIterator matchIt = re.globalMatch(TO_QSTRING(tag));
 
                 while (matchIt.hasNext()) {

--- a/src/helpers/qownnotesmarkdownhighlighter.cpp
+++ b/src/helpers/qownnotesmarkdownhighlighter.cpp
@@ -74,7 +74,7 @@ void QOwnNotesMarkdownHighlighter::highlightBlock(const QString &text) {
  */
 void QOwnNotesMarkdownHighlighter::highlightBrokenNotesLink(
     const QString &text) {
-    QRegularExpression regex(QStringLiteral(R"(note:\/\/[^\s\)>]+)"));
+    static const QRegularExpression regex(QStringLiteral(R"(note:\/\/[^\s\)>]+)"));
     QRegularExpressionMatch match = regex.match(text);
 
     if (match.hasMatch()) {    // check legacy note:// links
@@ -94,8 +94,7 @@ void QOwnNotesMarkdownHighlighter::highlightBrokenNotesLink(
         }
 
         // check <note file.md> links
-        regex = QRegularExpression(
-            QStringLiteral("<([^\\s`][^`]*?\\.[^`]*?[^\\s`]\\.md)>"));
+        static const QRegularExpression regex1(QStringLiteral("<([^\\s`][^`]*?\\.[^`]*?[^\\s`]\\.md)>"));
         match = regex.match(text);
 
         if (match.hasMatch()) {
@@ -114,8 +113,7 @@ void QOwnNotesMarkdownHighlighter::highlightBrokenNotesLink(
                 return;
             }
         } else {    // check [note](note file.md) links
-            regex = QRegularExpression(
-                QStringLiteral(R"(\[[^\[\]]+\]\((\S+\.md|.+?\.md)\)\B)"));
+            static const QRegularExpression regex1(QStringLiteral(R"(\[[^\[\]]+\]\((\S+\.md|.+?\.md)\)\B)"));
             match = regex.match(text);
 
             if (match.hasMatch()) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2734,9 +2734,8 @@ void MainWindow::readSettingsFromSettingsDialog(const bool isAppLaunch) {
                            ? QStringLiteral("search-notes-dark.svg")
                            : QStringLiteral("search-notes.svg");
     QString styleSheet = ui->searchLineEdit->styleSheet();
-    styleSheet.replace(
-        QRegularExpression(QStringLiteral("background-image: url\\(:.+\\);")),
-        QStringLiteral("background-image: url(:/images/%1);").arg(fileName));
+    static const QRegularExpression re(QStringLiteral("background-image: url\\(:.+\\);"));
+    styleSheet.replace(re, QStringLiteral("background-image: url(:/images/%1);").arg(fileName));
     ui->searchLineEdit->setStyleSheet(styleSheet);
 
     // initialize the shortcuts for the actions
@@ -2848,9 +2847,10 @@ void MainWindow::updateTreeWidgetItemHeight(QTreeWidget *treeWidget,
     QString styleText = treeWidget->styleSheet();
 
     // remove the old height stylesheet
-    styleText.remove(QRegularExpression(
+    static const QRegularExpression re(
         QStringLiteral("\nQTreeWidget::item \\{height: \\d+px\\}"),
-        QRegularExpression::CaseInsensitiveOption));
+                                    QRegularExpression::CaseInsensitiveOption);
+    styleText.remove(re);
 
     // add the new height stylesheet
     styleText += QStringLiteral("\nQTreeWidget::item {height: %1px}")
@@ -6360,9 +6360,8 @@ void MainWindow::openLocalUrl(QString urlString) {
     const QString scheme = url.scheme();
 
     if (scheme == QStringLiteral("noteid")) {    // jump to a note by note id
-        QRegularExpressionMatch match =
-            QRegularExpression(QStringLiteral(R"(^noteid:\/\/note-(\d+)$)"))
-                .match(urlString);
+        static const QRegularExpression re(QStringLiteral(R"(^noteid:\/\/note-(\d+)$)"));
+        QRegularExpressionMatch match = re.match(urlString);
 
         if (match.hasMatch()) {
             int noteId = match.captured(1).toInt();
@@ -6397,9 +6396,8 @@ void MainWindow::openLocalUrl(QString urlString) {
                 // if the name of the linked note only consists of numbers we cannot
                 // use host() to get the filename, it would get converted to an
                 // ip-address
-                QRegularExpressionMatch match =
-                    QRegularExpression(QStringLiteral(R"(^\w+:\/\/(\d+)$)"))
-                        .match(urlString);
+                static const QRegularExpression re(QStringLiteral(R"(^\w+:\/\/(\d+)$)"));
+                QRegularExpressionMatch match = re.match(urlString);
                 fileName =
                     match.hasMatch() ? match.captured(1) : url.host();
 
@@ -7884,7 +7882,7 @@ void MainWindow::insertHtmlAsMarkdownIntoCurrentNote(QString html) {
     html = Utils::Misc::htmlToMarkdown(std::move(html));
 
     // match image tags
-    QRegularExpression re(QStringLiteral("<img.+?src=[\"'](.+?)[\"'].*?>"),
+    static const QRegularExpression re(QStringLiteral("<img.+?src=[\"'](.+?)[\"'].*?>"),
                           QRegularExpression::CaseInsensitiveOption);
     QRegularExpressionMatchIterator i = re.globalMatch(html);
 
@@ -7921,7 +7919,8 @@ void MainWindow::insertHtmlAsMarkdownIntoCurrentNote(QString html) {
     showStatusBarMessage(tr("Downloading images finished"), 3000);
 
     // remove all html tags
-    html.remove(QRegularExpression(QStringLiteral("<.+?>")));
+    static const QRegularExpression tagRE(QStringLiteral("<.+?>"));
+    html.remove(tagRE);
 
     // unescape some html special characters
     html = Utils::Misc::unescapeHtml(std::move(html)).trimmed();
@@ -10257,7 +10256,7 @@ QString MainWindow::noteTextEditCurrentWord(bool withPreviousCharacters) {
     QString text = c.selectedText();
 
     if (withPreviousCharacters) {
-        QRegularExpression re(QStringLiteral("^[\\s\\n][^\\s]*"));
+        static const QRegularExpression re(QStringLiteral("^[\\s\\n][^\\s]*"));
         do {
             c.movePosition(QTextCursor::Left, QTextCursor::KeepAnchor);
             text = c.selectedText();

--- a/src/utils/gui.cpp
+++ b/src/utils/gui.cpp
@@ -52,7 +52,8 @@ void Utils::Gui::searchForTextInTreeWidget(QTreeWidget *treeWidget,
     QStringList searchList;
 
     if (searchFlags & TreeWidgetSearchFlag::EveryWordSearch) {
-        searchList = text.split(QRegularExpression(QStringLiteral("\\s+")));
+        static const QRegularExpression re(QStringLiteral("\\s+"));
+        searchList = text.split(re);
     } else {
         searchList << text;
     }
@@ -500,10 +501,10 @@ bool Utils::Gui::toggleCheckBoxAtCursor(QPlainTextEdit *textEdit) {
 
     bool result = false;
     auto text = cursor.selectedText();
-    auto reUnchecked = QRegularExpression(R"(([-\+\*]) \[ \])");
-    auto reChecked = QRegularExpression(R"(([-\+\*]) \[x\])");
-    auto reNumberUnchecked = QRegularExpression(R"(([\d+]\.) \[ \])");
-    auto reNumberChecked = QRegularExpression(R"(([\d+]\.) \[x\])");
+    static const auto reUnchecked = QRegularExpression(R"(([-\+\*]) \[ \])");
+    static const auto reChecked = QRegularExpression(R"(([-\+\*]) \[x\])");
+    static const auto reNumberUnchecked = QRegularExpression(R"(([\d+]\.) \[ \])");
+    static const auto reNumberChecked = QRegularExpression(R"(([\d+]\.) \[x\])");
 
     // try to toggle the checkbox
     if (reUnchecked.match(text).hasMatch()) {
@@ -596,7 +597,7 @@ bool Utils::Gui::autoFormatTableAtCursor(QPlainTextEdit *textEdit) {
         maxColumns = std::max(maxColumns, (int)stringList.count());
     }
 
-    const QRegularExpression headlineSeparatorRegExp(QStringLiteral(R"(^(:)?-+(:)?$)"));
+    static const QRegularExpression headlineSeparatorRegExp(QStringLiteral(R"(^(:)?-+(:)?$)"));
     QString justifiedText;
 
     const int lineCount = tableTextList.size();
@@ -775,10 +776,11 @@ void Utils::Gui::updateInterfaceFontSize(int fontSize) {
             .toBool();
 
     // remove old style
-    QString stylesheet = qApp->styleSheet().remove(QRegularExpression(
+    static const QRegularExpression re(
         QRegularExpression::escape(INTERFACE_OVERRIDE_STYLESHEET_PRE_STRING) +
         QStringLiteral(".*") +
-        QRegularExpression::escape(INTERFACE_OVERRIDE_STYLESHEET_POST_STRING)));
+        QRegularExpression::escape(INTERFACE_OVERRIDE_STYLESHEET_POST_STRING));
+    QString stylesheet = qApp->styleSheet().remove(re);
 
     if (overrideInterfaceFontSize) {
         int interfaceFontSize =

--- a/src/widgets/navigationwidget.cpp
+++ b/src/widgets/navigationwidget.cpp
@@ -102,8 +102,8 @@ QVector<Node> NavigationWidget::parseDocument(
             (elementType > MarkdownHighlighter::H6)) {
             continue;
         }
-        QString text =
-            block.text().remove(QRegularExpression(QStringLiteral("^#+\\s+")));
+        static const QRegularExpression re(QStringLiteral("^#+\\s+"));
+        QString text = block.text().remove(re);
 
         if (text.isEmpty()) {
             continue;

--- a/src/widgets/notepreviewwidget.cpp
+++ b/src/widgets/notepreviewwidget.cpp
@@ -108,7 +108,7 @@ QStringList NotePreviewWidget::extractGifUrls(const QString &text) const {
     QSet<QString> urlSet;
 
 #if (QT_VERSION < QT_VERSION_CHECK(5, 5, 0))
-    static QRegExp regex(R"(<img[^>]+src=\"(file:\/\/\/[^\"]+\.gif)\")",
+    QRegExp regex(R"(<img[^>]+src=\"(file:\/\/\/[^\"]+\.gif)\")",
                          Qt::CaseInsensitive);
 
     int pos = 0;


### PR DESCRIPTION
Constructing `QRegularExpression` is very expensive.

The change doesn't fix all the usages(since there are too many). I have fixed the ones that are more commonly used.