### PR TITLE
Disable PCH by default

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -132,12 +132,12 @@ jobs:
     - if: contains( matrix.os, 'ubuntu') && steps.changes.outputs.DO_BUILD
       name: Do Linux tests
       run: |
-        cd ../tests && qmake DEFINES+=INTEGRATION_TESTS && make -s -j 8
+        cd ../tests && qmake CONFIG+=debug CONFIG+=DEV_MODE DEFINES+=INTEGRATION_TESTS && make -s -j 8
         ../bin/tests/tests -platform minimal -txt
     - if: contains( matrix.os, 'macos') && steps.changes.outputs.DO_BUILD
       name: Do macOS tests
       run: |
-        cd ../tests && qmake DEFINES+=INTEGRATION_TESTS && make -s -j 8
+        cd ../tests && qmake CONFIG+=debug CONFIG+=DEV_MODE DEFINES+=INTEGRATION_TESTS && make -s -j 8
         ../bin/tests/tests.app/Contents/MacOS/tests -platform minimal -txt
     - if: contains( matrix.os, 'windows') && steps.changes.outputs.DO_BUILD
       name: Do Windows tests
@@ -158,7 +158,7 @@ jobs:
     - if: steps.changes.outputs.DO_BUILD && !(contains( matrix.os, 'windows') && ( matrix.qt-version == '5.15.2' ))
       name: Build QOwnNotes
       run: |
-        lrelease QOwnNotes.pro && qmake && make -j8
+        lrelease QOwnNotes.pro && qmake CONFIG+=debug CONFIG+=DEV_MODE && make -j8
 
       #
       # Build QOwnNotes Windows Release and store it as artifact

--- a/src/QOwnNotes.pro
+++ b/src/QOwnNotes.pro
@@ -14,9 +14,16 @@ lessThan(QT_MAJOR_VERSION, 6) {
 # Windows and macOS seem to ignore that
 #QT       += quick
 
-CONFIG += with_aspell precompile_header
+CONFIG += with_aspell
 
-PRECOMPILED_HEADER  = pch.h
+# enable pch for DEV_MODE
+# put any dev specific options here
+CONFIG(DEV_MODE) {
+    message("[DevMode] PCH Enabled")
+    CONFIG += precompile_header
+    PRECOMPILED_HEADER  = pch.h
+    HEADERS += pch.h
+}
 
 TARGET = QOwnNotes
 TEMPLATE = app
@@ -189,8 +196,7 @@ SOURCES += main.cpp\
     libraries/fuzzy/kfuzzymatcher.cpp \
     libraries/qr-code-generator/QrCode.cpp
 
-HEADERS  += pch.h \
-    mainwindow.h \
+HEADERS  += mainwindow.h \
     build_number.h \
     dialogs/attachmentdialog.h \
     entities/cloudconnection.h \


### PR DESCRIPTION
PCHs are now disabled by default since its only useful for devs. To
enable it run `qmake` like:
  - `qmake CONFIG+=DEV_MODE ..`

Also, use debug builds for our github build-tests since they are much
faster to build and enable pchs too.

For everything else PCH is now disabled.