### PR TITLE
Adds security token instructions & some pg re-org

### DIFF
--- a/webpage/src/getting-started/browser-extension.md
+++ b/webpage/src/getting-started/browser-extension.md
@@ -4,13 +4,24 @@ image: /img/bookmarks.png
 
 # QOwnNotes Web Companion browser extension
 
-Visit the [Chrome Web Store](https://chrome.google.com/webstore/detail/qownnotes-web-companion/pkgkfnampapjbopomdpnkckbjdnpkbkp) or the [Firefox Add-ons page](https://addons.mozilla.org/firefox/addon/qownnotes-web-companion) to install the [**QOwnNotes Web Companion browser extension**](https://github.com/qownnotes/web-companion/).
-
-You can also find the extension on [GitHub](https://github.com/qownnotes/web-companion/).
+Allows for clipping from a browser page and managing browser bookmarks across browsers and operating systems.
 
 ::: tip Info
-QOwnNotes needs to be running for the Web Companion browser extension to work. The browser extensions works **offline**, no internet connection needed.
+
+* QOwnNotes must be running for the Web Companion browser extension to work
+* No internet connection needed. The browser extensions works **offline**.
 :::
+
+## Installation
+
+1. Get the extension
+    * [Chrome Web Store](https://chrome.google.com/webstore/detail/qownnotes-web-companion/pkgkfnampapjbopomdpnkckbjdnpkbkp)
+    * [Firefox Add-ons page](https://addons.mozilla.org/firefox/addon/qownnotes-web-companion)
+    * You can also find the extension on [GitHub](https://github.com/qownnotes/web-companion/).
+2. Add the Security Token to configure the extension.
+    * The first time you click on the QOwnNotes browser extension icon you will receive a dialog box with a security token. Copy the token.
+    * Go to your browser's extension management location. Click into the QOwnNotes extension details.
+    * Paste the token into the Security Token field.
 
 ## Web clipper
 


### PR DESCRIPTION
The Security Token component of installation was confusing to me, so I am submitting this update to the documentation.

The re-organization at the top of the page is an attempt to both make the steps easy and short to follow and to allow for continued expansion of the page's content.