### PR TITLE
Don't check non note files for tags

### DIFF
--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -2221,9 +2221,7 @@ bool Note::refetch() {
  * Returns the suffix of the note file name
  */
 QString Note::fileNameSuffix() const {
-    QFileInfo fileInfo;
-    fileInfo.setFile(_fileName);
-    return fileInfo.suffix();
+    return QFileInfo(_fileName).suffix();
 }
 
 /**

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -8948,9 +8948,15 @@ void MainWindow::handleScriptingNotesTagUpdating() {
 
     // workaround when signal blocking doesn't work correctly
     directoryWatcherWorkaround(true, true);
-
-    const QVector<Note> &notes = Note::fetchAll();
+    const QString defExt = Note::defaultNoteFileExtension();
+    const QStringList exts = Note::customNoteFileExtensionList(QStringLiteral("."));
+    const QVector<Note> notes = Note::fetchAll();
     for (const Note &note : notes) {
+        // ignore non-note files
+        const auto suffix = note.fileNameSuffix();
+        if (defExt != suffix || !exts.contains(suffix)) {
+            continue;
+        }
         QSet<int> tagIdList;
         const QStringList tagNameList =
             ScriptingService::instance()


### PR DESCRIPTION
For me it ended up checking images for tags resulting in storing lots of
non-sense in the database. This then slows everything down as we can potentially have tons of tags in the database