### PR TITLE
Fix defaultNoteFileExtension handling in highlighter

### DIFF
--- a/src/libraries/qlitehtml/src/3rdparty/litehtml/src/html_tag.cpp
+++ b/src/libraries/qlitehtml/src/3rdparty/litehtml/src/html_tag.cpp
@@ -311,8 +311,12 @@ void litehtml::html_tag::parse_styles(bool is_reparse)
 		m_style.add(style, nullptr);
 	}
 
-	init_font();
 	document::ptr doc = get_document();
+	if (!doc) {
+        return;
+    }
+
+	init_font();
 
 	m_el_position	= (element_position)	value_index(get_style_property(_t("position"),		false,	_t("static")),		element_position_strings,	element_position_fixed);
 	m_text_align	= (text_align)			value_index(get_style_property(_t("text-align"),		true,	_t("left")),		text_align_strings,			text_align_left);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5197,7 +5197,7 @@ void MainWindow::updateCurrentFolderTooltip() {
  * Opens the settings dialog
  */
 void MainWindow::openSettingsDialog(int page, bool openScriptRepository) {
-    SettingsDialog *settingsDialog = new SettingsDialog(page, this);
+    QPointer<SettingsDialog> settingsDialog = new SettingsDialog(page, this);
     settingsDialog->readSettings();
 
     if (openScriptRepository) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -121,8 +121,14 @@
 #include "widgets/qownnotesmarkdowntextedit.h"
 #include "widgets/htmlpreviewwidget.h"
 
+static MainWindow* s_self = nullptr;
+
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent), ui(new Ui::MainWindow) {
+
+    // static reference to us
+    s_self = this;
+
     // handle logging as signal/slot to even more prevent crashes when
     // writing to the log-widget while the app is shutting down
     connect(this, &MainWindow::log, LogWidget::instance(), &LogWidget::log);
@@ -197,7 +203,6 @@ MainWindow::MainWindow(QWidget *parent)
     _noteSubFolderDockWidgetVisible = true;
     _noteExternallyRemovedCheckEnabled = true;
     _readOnlyButton = new QPushButton(this);
-    _settingsDialog = Q_NULLPTR;
     _lastNoteSelectionWasMultiple = false;
     _webSocketServerService = Q_NULLPTR;
     _closeEventWasFired = false;
@@ -207,8 +212,6 @@ MainWindow::MainWindow(QWidget *parent)
     this->setWindowTitle(QStringLiteral("QOwnNotes - version ") +
                          QStringLiteral(VERSION) + QStringLiteral(" - build ") +
                          QString::number(BUILD));
-
-    qApp->setProperty("mainWindow", QVariant::fromValue<MainWindow *>(this));
 
     ClientProxy proxy;
     // refresh the Qt proxy settings
@@ -762,6 +765,8 @@ MainWindow::~MainWindow() {
     }
 
     delete ui;
+
+    s_self = nullptr;
 }
 
 /*!
@@ -1072,7 +1077,7 @@ void MainWindow::buildNotesIndexAndLoadNoteDirectoryList(bool forceBuild,
  * Returns the global main window instance
  */
 MainWindow *MainWindow::instance() {
-    return qApp ? qApp->property("mainWindow").value<MainWindow *>() : nullptr;
+    return s_self;
 }
 
 /**
@@ -5192,26 +5197,21 @@ void MainWindow::updateCurrentFolderTooltip() {
  * Opens the settings dialog
  */
 void MainWindow::openSettingsDialog(int page, bool openScriptRepository) {
-    if (_settingsDialog == Q_NULLPTR) {
-        _settingsDialog = new SettingsDialog(page, this);
-    } else {
-        _settingsDialog->readSettings();
-        _settingsDialog->setCurrentPage(page);
-    }
+    SettingsDialog *settingsDialog = new SettingsDialog(page, this);
+    settingsDialog->readSettings();
 
     if (openScriptRepository) {
-        QTimer::singleShot(150, _settingsDialog,
-                           SLOT(searchScriptInRepository()));
+        QTimer::singleShot(10, settingsDialog, SLOT(searchScriptInRepository()));
     }
 
     // open the settings dialog
-    _settingsDialog->exec();
+    int ret = settingsDialog->exec();
 
-    // seems to safe a little leaking memory
-    // we must not null the dialog, this will crash if the ownCloud check
-    // tries to write to the labels and the dialog went away
-    //    delete(_settingsDialog);
-    //    _settingsDialog = Q_NULLPTR;
+    delete settingsDialog;
+
+    if (ret != QDialog::Accepted) {
+        return;
+    }
 
     // shows a restart application notification if needed
     if (showRestartNotificationIfNeeded()) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -87,6 +87,7 @@ class MainWindow : public QMainWindow {
    Q_SIGNALS:
     void currentNoteChanged(Note &note);
     void log(LogWidget::LogType logType, QString text);
+    void settingsChanged();
 
    public:
     enum CreateNewNoteOption {
@@ -756,7 +757,6 @@ private:
     IssueAssistantDialog *_issueAssistantDialog;
     StoredImagesDialog *_storedImagesDialog;
     StoredAttachmentsDialog *_storedAttachmentsDialog;
-    SettingsDialog *_settingsDialog;
     bool _noteExternallyRemovedCheckEnabled;
     QList<QAction *> _noteTextEditContextMenuActions;
     QList<QAction *> _noteListContextMenuActions;

--- a/src/services/scriptingservice.cpp
+++ b/src/services/scriptingservice.cpp
@@ -46,9 +46,10 @@ ScriptingService::ScriptingService(QObject *parent) : QObject(parent) {
     _engine = new QQmlEngine(this);
     _engine->rootContext()->setContextProperty(QStringLiteral("script"), this);
 #ifndef INTEGRATION_TESTS
-    _engine->rootContext()->setContextProperty(
-        QStringLiteral("mainWindow"),
-        qApp->property("mainWindow").value<MainWindow *>());
+    if (!MainWindow::instance()) {
+        qWarning() << "Unexpected null MainWindow in ScriptingService()";
+    }
+    _engine->rootContext()->setContextProperty(QStringLiteral("mainWindow"), MainWindow::instance());
 #endif
 
     // deprecated


### PR DESCRIPTION
We weren't ever setting _defaultNoteFileExtension which could lead to
bugs in some cases.

Some other related fixes:
- Note::defaultNoteFileExtension() is very expensive here. Used cached value.
- Introduce settingsChanged signal in mainWindow which is triggered
whenever settings change and can be used throughout the app to update
things dynamically
- remove setting mainWindow as a QProperty. instead just store a static
reference.
- Don't store the settings dialog. Create when needed.