### PR TITLE
Implement auto-selecting current item in navigation panel when current line changes

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3671,6 +3671,14 @@ bool MainWindow::jumpToNoteSubFolder(int noteSubFolderId) {
     return false;
 }
 
+bool MainWindow::selectNavigationItemAtPosition(int position)
+{
+    if (ui->navigationWidget->isVisible()) {
+        return ui->navigationWidget->selectItemAtPosition(position);
+    }
+    return false;
+}
+
 QString MainWindow::selectOwnCloudNotesFolder() {
     QString path = this->notesPath;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -188,6 +188,8 @@ class MainWindow : public QMainWindow {
 
     bool jumpToNoteSubFolder(int noteSubFolderId);
 
+    bool selectNavigationItemAtPosition(int position);
+
     Q_INVOKABLE bool createNewNoteSubFolder(QString folderName = QString());
 
     QString getLogText();

--- a/src/widgets/navigationwidget.cpp
+++ b/src/widgets/navigationwidget.cpp
@@ -114,9 +114,27 @@ QVector<Node> NavigationWidget::parseDocument(
     return nodes;
 }
 
+bool NavigationWidget::selectItemAtPosition(int position)
+{
+    if (!_positionItemMap.contains(position)) {
+        return false;
+    }
+
+    blockSignals(true);
+
+    const auto item = _positionItemMap[position];
+    setCurrentItem(item);
+
+    blockSignals(false);
+
+    return true;
+}
+
 void NavigationWidget::onParseCompleted() {
     QVector<Node> nodes = this->_parseFutureWatcher->result();
     if (_navigationTreeNodes == nodes) return;
+
+    _positionItemMap.clear();
     _navigationTreeNodes = std::move(nodes);
 
     clear();
@@ -132,6 +150,8 @@ void NavigationWidget::onParseCompleted() {
         item->setToolTip(
             0,
             tr("headline %1").arg(elementType - MarkdownHighlighter::H1 + 1));
+
+        _positionItemMap.insert(pos, item);
 
         // attempt to find a suitable parent item for the element type
         QTreeWidgetItem *lastHigherItem = findSuitableParentItem(elementType);

--- a/src/widgets/navigationwidget.h
+++ b/src/widgets/navigationwidget.h
@@ -15,6 +15,7 @@
 
 #include <QFutureWatcher>
 #include <QTreeWidget>
+#include <QMap>
 
 class QTextDocument;
 class QTreeWidgetItem;
@@ -41,6 +42,8 @@ class NavigationWidget : public QTreeWidget {
     void setDocument(const QTextDocument *document);
     static QVector<Node> parseDocument(const QTextDocument *const document);
 
+    bool selectItemAtPosition(int position);
+
    private slots:
     void onCurrentItemChanged(QTreeWidgetItem *current,
                               QTreeWidgetItem *previous);
@@ -55,6 +58,7 @@ class NavigationWidget : public QTreeWidget {
     QHash<int, QTreeWidgetItem *> _lastHeadingItemList;
     QFutureWatcher<QVector<Node>> *_parseFutureWatcher;
     QVector<Node> _navigationTreeNodes;
+    QMap<int, QTreeWidgetItem *> _positionItemMap;
 
     QTreeWidgetItem *findSuitableParentItem(int elementType) const;
 };

--- a/src/widgets/qownnotesmarkdowntextedit.cpp
+++ b/src/widgets/qownnotesmarkdowntextedit.cpp
@@ -72,6 +72,13 @@ QOwnNotesMarkdownTextEdit::QOwnNotesMarkdownTextEdit(QWidget *parent)
     connect(this, &QOwnNotesMarkdownTextEdit::zoomOut, this, [this](){
         onZoom(/*in=*/ false);
     });
+    connect(this, &QOwnNotesMarkdownTextEdit::newLinePosition, this, [this](int position){
+        if (!mainWindow) {
+            qWarning() << "No MainWindow! shouldn't happen!";
+            return;
+        }
+        mainWindow->selectNavigationItemAtPosition(position);
+    });
 
     connect(this, &QOwnNotesMarkdownTextEdit::urlClicked, this, [this](const QString &url){
         if (!mainWindow) {


### PR DESCRIPTION
Implements: #2136 
Requires PR: https://github.com/pbek/qmarkdowntextedit/pull/152

Can be implemented:
* as a script (providing a hook for current line changed in the markdowntextedit and a setter for setting the currently selected item in the navigation pane)
* as provided in this PR (maybe as an option)