### PR TITLE
Implement auto-selecting current item in navigation panel when current line changes

### DIFF
--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -1055,6 +1055,9 @@ void SettingsDialog::storePanelSettings() {
     settings.setValue(QStringLiteral("navigationPanelHideSearch"),
                       ui->navigationPanelHideSearchCheckBox->isChecked());
 
+    settings.setValue(QStringLiteral("navigationPanelAutoSelect"),
+                      ui->navigationPanelAutoSelectCheckBox->isChecked());
+
     settings.setValue(QStringLiteral("enableNoteTree"),
                       ui->enableNoteTreeCheckBox->isChecked());
 }
@@ -1649,6 +1652,9 @@ void SettingsDialog::readPanelSettings() {
     // Navigation Panel Options
     ui->navigationPanelHideSearchCheckBox->setChecked(
         settings.value(QStringLiteral("navigationPanelHideSearch")).toBool());
+
+    ui->navigationPanelAutoSelectCheckBox->setChecked(
+        settings.value(QStringLiteral("navigationPanelAutoSelect")).toBool());
 
     ui->enableNoteTreeCheckBox->setChecked(Utils::Misc::isEnableNoteTree());
 }

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -5814,6 +5814,13 @@ git config --global user.name &quot;Your name&quot;</string>
                   </property>
                  </widget>
                 </item>
+                <item>
+                 <widget class="QCheckBox" name="navigationPanelAutoSelectCheckBox">
+                  <property name="text">
+                   <string>Auto-select items in navigation panel when changing cursor position</string>
+                  </property>
+                 </widget>
+                </item>
                </layout>
               </widget>
              </item>
@@ -6838,8 +6845,8 @@ Just test yourself if you get sync conflicts and set a higher value if so.</stri
   <tabstop>enableSocketServerCheckBox</tabstop>
  </tabstops>
  <resources>
-  <include location="../breeze-dark-qownnotes.qrc"/>
   <include location="../breeze-qownnotes.qrc"/>
+  <include location="../breeze-dark-qownnotes.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3671,6 +3671,13 @@ bool MainWindow::jumpToNoteSubFolder(int noteSubFolderId) {
     return false;
 }
 
+void MainWindow::selectNavigationItemAtPosition(int position)
+{
+    if (ui->navigationWidget->isVisible()) {
+        ui->navigationWidget->selectItemForCursorPosition(position);
+    }
+}
+
 QString MainWindow::selectOwnCloudNotesFolder() {
     QString path = this->notesPath;
 
@@ -4502,7 +4509,8 @@ void MainWindow::setNoteTextFromNote(Note *note, bool updateNoteTextViewOnly,
  */
 void MainWindow::startNavigationParser() {
     if (ui->navigationWidget->isVisible())
-        ui->navigationWidget->parse(activeNoteTextEdit()->document());
+        ui->navigationWidget->parse(activeNoteTextEdit()->document(),
+                                    activeNoteTextEdit()->textCursor().position());
 }
 
 /**

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -188,6 +188,8 @@ class MainWindow : public QMainWindow {
 
     bool jumpToNoteSubFolder(int noteSubFolderId);
 
+    void selectNavigationItemAtPosition(int position);
+
     Q_INVOKABLE bool createNewNoteSubFolder(QString folderName = QString());
 
     QString getLogText();

--- a/src/widgets/navigationwidget.cpp
+++ b/src/widgets/navigationwidget.cpp
@@ -124,18 +124,15 @@ void NavigationWidget::selectItemForCursorPosition(int position)
 
     int itemIndex = findItemIndexforCursorPosition(position);
 
-    if (itemIndex < 0) {
-        blockSignals(true);
-        setCurrentItem(nullptr);
-        blockSignals(false);
-        return;
+    QTreeWidgetItem *itemToSelect{nullptr};
+    if (itemIndex >= 0) {
+        QTreeWidgetItemIterator it(this);
+        it += itemIndex;
+        itemToSelect = *it;
     }
 
-    QTreeWidgetItemIterator it(this);
-    it += itemIndex;
-
     blockSignals(true);
-    setCurrentItem(*it);
+    setCurrentItem(itemToSelect);
     blockSignals(false);
 }
 

--- a/src/widgets/navigationwidget.h
+++ b/src/widgets/navigationwidget.h
@@ -15,7 +15,6 @@
 
 #include <QFutureWatcher>
 #include <QTreeWidget>
-#include <QMap>
 
 class QTextDocument;
 class QTreeWidgetItem;

--- a/src/widgets/navigationwidget.h
+++ b/src/widgets/navigationwidget.h
@@ -15,6 +15,7 @@
 
 #include <QFutureWatcher>
 #include <QTreeWidget>
+#include <QMap>
 
 class QTextDocument;
 class QTreeWidgetItem;
@@ -37,9 +38,11 @@ class NavigationWidget : public QTreeWidget {
     explicit NavigationWidget(QWidget *parent = 0);
     ~NavigationWidget();
 
-    void parse(const QTextDocument *document);
+    void parse(const QTextDocument *document, int textCursorPosition);
     void setDocument(const QTextDocument *document);
     static QVector<Node> parseDocument(const QTextDocument *const document);
+
+    void selectItemForCursorPosition(int position);
 
    private slots:
     void onCurrentItemChanged(QTreeWidgetItem *current,
@@ -55,6 +58,8 @@ class NavigationWidget : public QTreeWidget {
     QHash<int, QTreeWidgetItem *> _lastHeadingItemList;
     QFutureWatcher<QVector<Node>> *_parseFutureWatcher;
     QVector<Node> _navigationTreeNodes;
+    int _latestTextCursorPosition;
 
     QTreeWidgetItem *findSuitableParentItem(int elementType) const;
+    int findItemIndexforCursorPosition(int position) const;
 };

--- a/src/widgets/navigationwidget.h
+++ b/src/widgets/navigationwidget.h
@@ -58,7 +58,7 @@ class NavigationWidget : public QTreeWidget {
     QHash<int, QTreeWidgetItem *> _lastHeadingItemList;
     QFutureWatcher<QVector<Node>> *_parseFutureWatcher;
     QVector<Node> _navigationTreeNodes;
-    int _latestTextCursorPosition;
+    int _cursorPosition;
 
     QTreeWidgetItem *findSuitableParentItem(int elementType) const;
     int findItemIndexforCursorPosition(int position) const;

--- a/src/widgets/qownnotesmarkdowntextedit.cpp
+++ b/src/widgets/qownnotesmarkdowntextedit.cpp
@@ -72,6 +72,13 @@ QOwnNotesMarkdownTextEdit::QOwnNotesMarkdownTextEdit(QWidget *parent)
     connect(this, &QOwnNotesMarkdownTextEdit::zoomOut, this, [this](){
         onZoom(/*in=*/ false);
     });
+    connect(this, &QOwnNotesMarkdownTextEdit::newLinePosition, this, [this](int position){
+        if (!mainWindow) {
+            qWarning() << "No MainWindow! shouldn't happen!";
+            return;
+        }
+        mainWindow->selectNavigationItemAtPosition(position);
+    });
 
     connect(this, &QOwnNotesMarkdownTextEdit::urlClicked, this, [this](const QString &url){
         if (!mainWindow) {

--- a/src/widgets/qownnotesmarkdowntextedit.cpp
+++ b/src/widgets/qownnotesmarkdowntextedit.cpp
@@ -79,7 +79,12 @@ QOwnNotesMarkdownTextEdit::QOwnNotesMarkdownTextEdit(QWidget *parent)
             qWarning() << "No MainWindow! shouldn't happen!";
             return;
         }
-        mainWindow->selectNavigationItemAtPosition(textCursor().block().position());
+        const bool autoSelect =
+            QSettings().value(QStringLiteral("navigationPanelAutoSelect"), false)
+                .toBool();
+        if (autoSelect) {
+            mainWindow->selectNavigationItemAtPosition(textCursor().block().position());
+        }
     });
 
     connect(this, &QOwnNotesMarkdownTextEdit::urlClicked, this, [this](const QString &url){

--- a/src/widgets/qownnotesmarkdowntextedit.cpp
+++ b/src/widgets/qownnotesmarkdowntextedit.cpp
@@ -72,12 +72,14 @@ QOwnNotesMarkdownTextEdit::QOwnNotesMarkdownTextEdit(QWidget *parent)
     connect(this, &QOwnNotesMarkdownTextEdit::zoomOut, this, [this](){
         onZoom(/*in=*/ false);
     });
-    connect(this, &QOwnNotesMarkdownTextEdit::newLinePosition, this, [this](int position){
+
+    connect(this, &QPlainTextEdit::cursorPositionChanged, this,
+            [this]() {
         if (!mainWindow) {
             qWarning() << "No MainWindow! shouldn't happen!";
             return;
         }
-        mainWindow->selectNavigationItemAtPosition(position);
+        mainWindow->selectNavigationItemAtPosition(textCursor().block().position());
     });
 
     connect(this, &QOwnNotesMarkdownTextEdit::urlClicked, this, [this](const QString &url){


### PR DESCRIPTION
Implements: https://github.com/pbek/QOwnNotes/issues/2136

This will highlight the navigation item corresponding to the current text cursor position, as opposed to PR https://github.com/pbek/QOwnNotes/pull/2383 , which requires that the text cursor is located on a heading line in order to select the corresponding navigation item.

Again, this functionality could be available as an option.