### PR TITLE
Clean up logWidget

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -131,13 +131,11 @@ MainWindow::MainWindow(QWidget *parent)
     // static reference to us
     s_self = this;
 
-    // handle logging as signal/slot to even more prevent crashes when
-    // writing to the log-widget while the app is shutting down
-    connect(this, &MainWindow::log, LogWidget::instance(), &LogWidget::log);
+    _logWidget = new LogWidget(this);
+    connect(this, &MainWindow::log, _logWidget, &LogWidget::log);
 
     // use our custom log handler
     qInstallMessageHandler(LogWidget::logMessageOutput);
-    qApp->setProperty("loggingEnabled", true);
 
 #ifdef Q_OS_MAC
     // disable icons in the menu
@@ -724,14 +722,6 @@ MainWindow::~MainWindow() {
     // (#1269, may cause an interruption of the shutdown process)
     //    gitCommitCurrentNoteFolder();
 
-    qApp->setProperty("loggingEnabled", false);
-
-    if (showSystemTray) {
-        // if we are using the system tray lets delete the log window so the
-        // app can quit
-        delete (LogWidget::instance());
-    }
-
     delete ui;
 
     s_self = nullptr;
@@ -871,7 +861,7 @@ void MainWindow::initDockWidgets() {
 
     _logDockWidget = new QDockWidget(tr("Log"), this);
     _logDockWidget->setObjectName(QStringLiteral("logDockWidget"));
-    _logDockWidget->setWidget(LogWidget::instance());
+    _logDockWidget->setWidget(_logWidget);
     _logDockTitleBarWidget = _logDockWidget->titleBarWidget();
     addDockWidget(Qt::RightDockWidgetArea, _logDockWidget, Qt::Vertical);
     _logDockWidget->hide();
@@ -5575,19 +5565,11 @@ void MainWindow::handleNoteTextChanged() {
 }
 
 void MainWindow::on_action_Quit_triggered() {
-    // this will be done again in the destructor, but we want to make sure
-    // nothing is logged to the log widget that might already be destroyed
-    qApp->setProperty("loggingEnabled", false);
-
     storeSettings();
     QApplication::quit();
 }
 
 void MainWindow::quitApp() {
-    // this will be done again in the destructor, but we want to make sure
-    // nothing is logged to the log widget that might already be destroyed
-    qApp->setProperty("loggingEnabled", false);
-
     QApplication::quit();
 }
 
@@ -11317,8 +11299,7 @@ void MainWindow::on_noteOperationsButton_clicked() {
  * Returns the text of the log widget
  */
 QString MainWindow::getLogText() {
-    auto *widget = dynamic_cast<LogWidget *>(_logDockWidget->widget());
-    return widget->getLogText();
+    return _logWidget->getLogText();
 }
 
 /**

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -759,6 +759,7 @@ private:
     QDockWidget *_notePreviewDockWidget;
     QDockWidget *_logDockWidget;
     QDockWidget *_scriptingDockWidget;
+    class LogWidget *_logWidget;
     QWidget *_taggingDockTitleBarWidget;
     QWidget *_noteSubFolderDockTitleBarWidget;
     QWidget *_noteSearchDockTitleBarWidget;

--- a/src/widgets/logwidget.cpp
+++ b/src/widgets/logwidget.cpp
@@ -9,12 +9,15 @@
 #include <QMenu>
 #include <QScrollBar>
 #include <QSettings>
+#include <QPointer>
 
 #include "mainwindow.h"
 
 #ifndef INTEGRATION_TESTS
 #include "ui_logwidget.h"
 #endif
+
+static QPointer<LogWidget> s_logWidget = nullptr;
 
 LogWidget::LogWidget(QWidget *parent)
     : QFrame(parent)
@@ -24,7 +27,9 @@ LogWidget::LogWidget(QWidget *parent)
 #endif
 {
 #ifndef INTEGRATION_TESTS
-    connect(this, &LogWidget::destroyed, this, &LogWidget::onDestroyed);
+
+    // static reference to us for use in the message handler
+    s_logWidget = this;
 
     ui->setupUi(this);
 
@@ -40,9 +45,6 @@ LogWidget::LogWidget(QWidget *parent)
     // we use a different context menu here, not default one
     disconnect(ui->logTextEdit, &QPlainTextEdit::customContextMenuRequested, nullptr, nullptr);
     connect(ui->logTextEdit, &QPlainTextEdit::customContextMenuRequested, this, &LogWidget::on_logTextEdit_customContextMenuRequested);
-
-    connect(ui->logTextEdit, &QOwnNotesMarkdownTextEdit::destroyed, this,
-            &LogWidget::onDestroyed);
 
     ui->buttonFrame->hide();
     const QSettings settings;
@@ -159,7 +161,7 @@ void LogWidget::log(LogWidget::LogType logType, const QString &text) {
     logToFileIfAllowed(logType, text);
 
     // return if logging wasn't enabled or if widget is not visible
-    if (!qApp->property("loggingEnabled").toBool() || !isVisible()) {
+    if (!isVisible()) {
         return;
     }
 
@@ -249,11 +251,6 @@ void LogWidget::log(LogWidget::LogType logType, const QString &text) {
     const bool scrollDown =
         scrollBar->value() >= (scrollBar->maximum() - scrollBar->singleStep());
 
-    // return if logging isn't enabled any more
-    if (!qApp->property("loggingEnabled").toBool()) {
-        return;
-    }
-
     const QSignalBlocker blocker(ui->logTextEdit);
     Q_UNUSED(blocker)
 
@@ -309,37 +306,6 @@ QString LogWidget::logTypeText(LogType logType) {
 
     return type;
 }
-
-/**
- * Fetches the global instance of the class
- * The instance will be created if it doesn't exist.
- */
-LogWidget *LogWidget::instance() {
-    LogWidget *logWidget = nullptr;
-#ifndef INTEGRATION_TESTS
-    logWidget = qApp->property("logWidget").value<LogWidget *>();
-#endif
-
-    if (logWidget == Q_NULLPTR) {
-        logWidget = createInstance(nullptr);
-    }
-
-    return logWidget;
-}
-
-/**
- * Creates a global instance of the class
- */
-LogWidget *LogWidget::createInstance(QWidget *parent) {
-    auto *logWidget = new LogWidget(parent);
-
-#ifndef INTEGRATION_TESTS
-    qApp->setProperty("logWidget", QVariant::fromValue<LogWidget *>(logWidget));
-#endif
-
-    return logWidget;
-}
-
 /**
  * Custom log output
  */
@@ -381,13 +347,12 @@ void LogWidget::logMessageOutput(QtMsgType type,
     }
 
 #ifndef INTEGRATION_TESTS
-    MainWindow *mainWindow = MainWindow::instance();
 
-    if (mainWindow != Q_NULLPTR) {
-        // handle logging as signal/slot to even more prevent crashes when
-        // writing to the log-widget while the app is shutting down
-        emit(mainWindow->log(logType, msg));
+    if (s_logWidget) {
+        // Use auto connection to handle the case if a message is coming in from a different thread.
+        QMetaObject::invokeMethod(s_logWidget, "log", Qt::AutoConnection, Q_ARG(LogWidget::LogType, logType), Q_ARG(QString, msg));
     }
+
 #else
     Q_UNUSED(logType)
 #endif
@@ -460,19 +425,6 @@ void LogWidget::on_logTextEdit_customContextMenuRequested(QPoint pos) {
     }
 #else
     Q_UNUSED(pos)
-#endif
-}
-
-/**
- * In case that method gets ever called it should disable logging if an
- * object is destroyed
- *
- * @param obj
- */
-void LogWidget::onDestroyed(QObject *obj) {
-    Q_UNUSED(obj)
-#ifndef INTEGRATION_TESTS
-    qApp->setProperty("loggingEnabled", false);
 #endif
 }
 

--- a/src/widgets/logwidget.h
+++ b/src/widgets/logwidget.h
@@ -34,11 +34,10 @@ class LogWidget : public QFrame {
         StatusLogType,
         ScriptingLogType
     };
+    Q_ENUM(LogType);
 
     explicit LogWidget(QWidget *parent = 0);
     ~LogWidget();
-    static LogWidget *instance();
-    static LogWidget *createInstance(QWidget *parent);
     static void logMessageOutput(QtMsgType type,
                                  const QMessageLogContext &context,
                                  const QString &msg);
@@ -54,8 +53,6 @@ class LogWidget : public QFrame {
     void on_clearButton_clicked();
 
     void on_logTextEdit_customContextMenuRequested(QPoint pos);
-
-    void onDestroyed(QObject *obj = Q_NULLPTR);
 
    private:
     Ui::LogWidget *ui;


### PR DESCRIPTION
Remove all qproperty based checks. Instead become a child of mainwindow
to have a somewhat clear ownership semantics. This will prevent using
extra hacks to handle cases where we are getting destroyed and logging.