### PR TITLE
[website] (re)mention paragraph breaks

### DIFF
--- a/webpage/src/getting-started/markdown.md
+++ b/webpage/src/getting-started/markdown.md
@@ -298,6 +298,7 @@ ___
 
 - You can break a paragraph into more than a single line for easier editing, they still render as a single paragraph with no breaks.
 - You can force a line break inside a paragraph by ending a line with two spaces.
+- You can make a separate paragraph by delimiting it by empty lines.
 
 ::: tip
 You can enter two spaces and a newline with <kbd>⇧ Shift</kbd> + <kbd>Return</kbd>.


### PR DESCRIPTION
#2398 mentioned that the documentation about line breaks is ambiguous. It was discussed and improved in that issue, and this PR continues improving it.

The last commit discussed in that issue had improved the wording about soft line breaks and hard line breaks (the second and third bullets [originally](https://github.com/pbek/QOwnNotes/blob/3215c4984f4f4bf0e6fabfdd87990e7ee9a86099/webpage/src/getting-started/markdown.md#line-breaks)), but it removed the first bullet, which was about paragraph breaks.

This PR tries to re-incorporate that in the same style of the new bullets.