### PR TITLE
Fix implicit connections

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -653,6 +653,9 @@ int main(int argc, char *argv[]) {
 #ifdef Q_OS_MAC
         loadMacTranslations(translatorOSX, translatorOSX2, translatorOSX3, translatorOSX4,
                             QCoreApplication::applicationDirPath(), locale);
+
+        // disable icons in the menu
+        QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, true);
 #endif
 
         const bool result = mainStartupMisc(arguments);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -131,23 +131,18 @@ MainWindow::MainWindow(QWidget *parent)
     // static reference to us
     s_self = this;
 
+    ui->setupUi(this);
+
     _logWidget = new LogWidget(this);
     connect(this, &MainWindow::log, _logWidget, &LogWidget::log);
 
     // use our custom log handler
     qInstallMessageHandler(LogWidget::logMessageOutput);
 
-#ifdef Q_OS_MAC
-    // disable icons in the menu
-    QApplication::instance()->setAttribute(Qt::AA_DontShowIconsInMenus, true);
-#endif
-
     QSettings settings;
     _noteEditIsCentralWidget =
         settings.value(QStringLiteral("noteEditIsCentralWidget"), true)
             .toBool();
-
-    ui->setupUi(this);
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
     ui->noteEditTabWidget->setTabBarAutoHide(true);


### PR DESCRIPTION
One conclusion that I can derive from this is that no one should use the
implicit `on_blablah_xChanged()` functions to handle events. Its super
crappy and doesn't even give a warning in case things break. But seems
like we use it all over the place so anything can break at any time \o/