### PR TITLE
Remove current line highlight code from QOwnNotesMarkdownTextEdit

### DIFF
--- a/src/widgets/qownnotesmarkdowntextedit.h
+++ b/src/widgets/qownnotesmarkdowntextedit.h
@@ -90,9 +90,6 @@ class QOwnNotesMarkdownTextEdit : public QMarkdownTextEdit {
     void resizeEvent(QResizeEvent *event) override;
     bool eventFilter(QObject *obj, QEvent *event) override;
 
-   public slots:
-    void highlightCurrentLine();
-
    private:
     MainWindow *mainWindow = nullptr;
     bool _isSpellCheckingDisabled = false;


### PR DESCRIPTION
The feature is now implemented in QMarkdownTextEdit. We just need to
enable it according to our settings.