### PR TITLE
Ignore qmake+make build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,12 @@ snap/.snapcraft/state
 src/languages/*.qm
 .vscode/
 CMakeLists.txt.user*
+*.o
+qrc_*.cpp
+moc_*.cpp
+moc_*.h
+ui_*.h
+/src/.qmake.stash
+/src/Makefile
+/src/QOwnNotes
+


### PR DESCRIPTION
While working on #2423 and building QOwnNotes with `qmake` and `make`, I found that almost all built files (e.g., `*.o`) are not ignored in Git. This PR makes them all ignored.