### PR TITLE
Fix QProcess usages

### DIFF
--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -29,7 +29,6 @@
 #include <QKeySequenceEdit>
 #include <QMenu>
 #include <QMessageBox>
-#include <QProcess>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
 #include <QSettings>

--- a/src/libraries/fakevim/fakevim/fakevimhandler.cpp
+++ b/src/libraries/fakevim/fakevim/fakevimhandler.cpp
@@ -84,6 +84,7 @@
 #include <QMimeData>
 #include <QSharedPointer>
 #include <QDir>
+#include <QStandardPaths>
 
 #include <algorithm>
 #include <climits>
@@ -965,6 +966,12 @@ static QString fromLocalEncoding(const QByteArray &data)
 
 static QString getProcessOutput(const QString &command, const QString &input)
 {
+    // ensure the executable exists in some standard path and isn't random
+    const auto fullCmdPath = QStandardPaths::findExecutable(command);
+    if (fullCmdPath.isEmpty()) {
+        return {};
+    }
+
     QProcess proc;
 #if QT_VERSION >= QT_VERSION_CHECK(5,15,0)
     QStringList arguments = QProcess::splitCommand(command);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -68,7 +68,6 @@
 #include <QPointer>
 #include <QPrintDialog>
 #include <QPrinter>
-#include <QProcess>
 #include <QProgressDialog>
 #include <QQmlApplicationEngine>
 #include <QQmlComponent>

--- a/src/utils/git.h
+++ b/src/utils/git.h
@@ -24,7 +24,7 @@ namespace Git {
 void commitCurrentNoteFolder();
 bool executeCommand(const QString& command, const QStringList& arguments,
                     QProcess* process = Q_NULLPTR, bool withErrorDialog = false);
-bool executeGitCommand(const QStringList& arguments, QProcess* process = Q_NULLPTR,
+bool executeGitCommand(const QString &gitExe, const QStringList& arguments, QProcess* process = Q_NULLPTR,
                        bool withErrorDialog = true);
 QString gitCommand();
 void showLog(const QString& filePath);

--- a/src/utils/misc.cpp
+++ b/src/utils/misc.cpp
@@ -152,11 +152,11 @@ void Utils::Misc::openFolderSelect(const QString &absolutePath) {
         openPath(path.left(path.lastIndexOf("/")));
     }
 #elif defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
-    if (QFileInfo(path).exists()) {
+    static const auto fullXdgMimePath = QStandardPaths::findExecutable(QStringLiteral("xdg-mime"));
+    if (!fullXdgMimePath.isEmpty() && QFileInfo(path).exists()) {
         QProcess proc;
         QString output;
-        proc.start(QStringLiteral("xdg-mime"),
-                   QStringList{"query", "default", "inode/directory"});
+        proc.start(fullXdgMimePath, QStringList{"query", "default", "inode/directory"});
         proc.waitForFinished();
         output = proc.readLine().simplified();
         if (output == QStringLiteral("dolphin.desktop") ||


### PR DESCRIPTION
For security, we must always ensure that the process we are executing is
present in a standard location.