### PR TITLE
Fix wrong function call

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -134,7 +134,7 @@ struct FileWatchDisabler {
     ~FileWatchDisabler()
     {
         Q_ASSERT(_mainWindow);
-        _mainWindow->connectFileWatcher();
+        _mainWindow->connectFileWatcher(/*delayed = */ true);
     }
 private:
     MainWindow *const _mainWindow = nullptr;


### PR DESCRIPTION
Follow up. The connect needs to be delayed to avoid late note directory
modification signals.