### PR TITLE
Use FileWatchDisabler in removeConflictedNotesDatabaseCopies

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3465,8 +3465,7 @@ void MainWindow::removeConflictedNotesDatabaseCopies() {
     const QSignalBlocker blocker(this->noteDirectoryWatcher);
     Q_UNUSED(blocker)
 
-    // we try to fix problems with the blocker
-    directoryWatcherWorkaround(true);
+    FileWatchDisabler disable(this);
 
     while (it.hasNext()) {
         const QString &file = it.next();
@@ -3525,8 +3524,6 @@ void MainWindow::removeConflictedNotesDatabaseCopies() {
 
     showStatusBarMessage(
         tr("Removed %n conflicted database copies", "", count));
-
-    directoryWatcherWorkaround(false);
 }
 
 /**


### PR DESCRIPTION
This fixes the bug that note created outside QON wasn't detected. The
problem was that if we early returned on

```
if (count == 0) {
   return;
}
```
we left file watch disabled forever.

Using FileWatchDisabler does the same thing, but is less error prone
as it will auto enable file watch on scope exit.