### PR TITLE
Update Note Text when reload by external editor

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2944,7 +2944,7 @@ void MainWindow::notesWereModified(const QString &str) {
 
         // rebuild and reload the notes directory list
         buildNotesIndexAndLoadNoteDirectoryList();
-        setCurrentNote(std::move(this->currentNote), false);
+        setCurrentNote(std::move(this->currentNote), true);
     }
 }
 


### PR DESCRIPTION
when i open a note, and this current note is synced with delete and add way, the note text can't change if the code is below
setCurrentNote(std::move(this->currentNote), **false**);

so i change **false** to **true**, and now it is ok