### PR TITLE
Fix javascript highlighting (resolves #2468)

### DIFF
--- a/src/helpers/codetohtmlconverter.cpp
+++ b/src/helpers/codetohtmlconverter.cpp
@@ -32,7 +32,7 @@ void CodeToHtmlConverter::initCodeLangs() Q_DECL_NOTHROW {
         {QStringLiteral("html"), CodeToHtmlConverter::CodeXML},
         {QStringLiteral("ini"), CodeToHtmlConverter::CodeINI},
         {QStringLiteral("java"), CodeToHtmlConverter::CodeJava},
-        {QStringLiteral("javascript"), CodeToHtmlConverter::CodeJava},
+        {QStringLiteral("javascript"), CodeToHtmlConverter::CodeJs},
         {QStringLiteral("js"), CodeToHtmlConverter::CodeJs},
         {QStringLiteral("json"), CodeToHtmlConverter::CodeJSON},
         {QStringLiteral("make"), CodeToHtmlConverter::CodeMake},


### PR DESCRIPTION
This change fixes the issue reported in #2468 by making `javascript` in code blocks highlight as JavaScript rather than Java.