### PR TITLE
[website] improve the navbar and sidebar

### DIFF
--- a/webpage/src/.vuepress/config.js
+++ b/webpage/src/.vuepress/config.js
@@ -84,6 +84,7 @@ const faqNavItems = [
 
 const gettingStartedNavItem = '/getting-started/overview';
 const installationNavItem = '/installation/';
+const changelogNavItem = '/changelog';
 const donateNavItem = '/contributing/donate';
 
 module.exports = {
@@ -240,11 +241,15 @@ module.exports = {
           {
             title: 'Blog',
             children: utils.getChildren('src', 'blog', true)
+          },
+          {
+            title: 'Changelog',
+            children: [ changelogNavItem ]
           }
         ]
       },
       '/de/': {
-        selectText: 'Sprachen',
+        selectText: '🌍',
         label: 'Deutsch',
         editLinkText: 'Hilf uns diese Seite zu verbessern!',
         algolia: {
@@ -298,11 +303,15 @@ module.exports = {
           {
             title: 'Blog (auf Englisch)',
             children: utils.getChildren('src', 'blog', true)
+          },
+          {
+            title: 'Änderungsprotokoll (auf Englisch)',
+            children: [ changelogNavItem ]
           }
         ]
       },
       '/es/': {
-        selectText: 'Idiomas',
+        selectText: '🌍',
         label: 'Español',
         editLinkText: '¡Ayúdanos a mejorar este sitio!',
         algolia: {
@@ -356,11 +365,15 @@ module.exports = {
           {
             title: 'Blog (en inglés)',
             children: utils.getChildren('src', 'blog', true)
+          },
+          {
+            title: 'Registro de cambios (en inglés)',
+            children: [ changelogNavItem ]
           }
         ]
       },
       '/hu/': {
-        selectText: 'Nyelvek',
+        selectText: '🌍',
         label: 'Magyar',
         editLinkText: 'Segítsen javítani ezt az oldalt!',
         algolia: {
@@ -414,11 +427,15 @@ module.exports = {
           {
             title: 'Blog (angolul)',
             children: utils.getChildren('src', 'blog', true)
+          },
+          {
+            title: 'Változások (angolul)',
+            children: [ changelogNavItem ]
           }
         ]
       },
        '/fr/': {
-        selectText: 'Langues',
+        selectText: '🌍',
         label: 'Français',
         editLinkText: 'Aidez-nous à améliorer ce site!',
          algolia: {
@@ -472,11 +489,15 @@ module.exports = {
           {
             title: 'Blog (en anglais)',
             children: utils.getChildren('src', 'blog', true)
+          },
+          {
+            title: 'Changelog (en anglais)',
+            children: [ changelogNavItem ]
           }
         ]
       },
       '/it/': {
-        selectText: 'Lingue',
+        selectText: '🌍',
         label: 'Italiano',
         editLinkText: 'Aiutaci a migliorare questo sito!',
         algolia: {
@@ -530,11 +551,15 @@ module.exports = {
           {
             title: 'Blog (in inglese)',
             children: utils.getChildren('src', 'blog', true)
+          },
+          {
+            title: 'Log delle modifiche (in inglese)',
+            children: [ changelogNavItem ]
           }
         ]
       },
       '/fa/': {
-        selectText: 'زبان ها',
+        selectText: '🌍',
         label: 'فارسی',
         editLinkText: 'در اصلاح این صفحه ما را یاری کنید!',
         algolia: {
@@ -588,11 +613,15 @@ module.exports = {
           {
             title: 'وبلاگ (به انگلیسی)',
             children: utils.getChildren('src', 'blog', true)
+          },
+          {
+            title: 'گزارش تغییرات (به انگلیسی)',
+            children: [ changelogNavItem ]
           }
         ]
       },
       '/nl/': {
-        selectText: 'Talen',
+        selectText: '🌍',
         label: 'Nederlands',
         editLinkText: 'Help ons deze pagina te verbeteren!',
         algolia: {
@@ -646,13 +675,16 @@ module.exports = {
           {
             title: 'Blog (in het Engels)',
             children: utils.getChildren('src', 'blog', true)
+          },
+          {
+            title: 'Changelog (in het Engels)',
+            children: [ changelogNavItem ]
           }
         ]
       },
       '/ar/': {
-        selectText: 'اللغات',
+        selectText: '🌍',
         label: 'العربية',
-        ariaLabel: 'Languages',
         editLinkText: 'ساعدنا في تحسين هذه الصفحة!',
         algolia: {
           apiKey: '35f878f4b712d5ab6a659eb0a6c71576',
@@ -705,6 +737,10 @@ module.exports = {
           {
             title: 'المدونة (بالإنجليزية)',
             children: utils.getChildren('src', 'blog', true)
+          },
+          {
+            title: 'سجل التغييرات (بالإنجليزية)',
+            children: [ changelogNavItem ]
           }
         ]
       }

--- a/webpage/src/.vuepress/config.js
+++ b/webpage/src/.vuepress/config.js
@@ -270,6 +270,10 @@ module.exports = {
             link: utils.getNavItemForLanguage(installationNavItem, 'de'),
           },
           {
+            text: 'Blog (auf Englisch)',
+            link: '/blog/',
+          },
+          {
             text: 'Änderungsprotokoll',
             link: changelogNavItem,
             collapsable: true,
@@ -308,6 +312,10 @@ module.exports = {
           {
             title: 'FAQ',
             children: utils.getNavItemsForLanguage(faqNavItems, "de")
+          },
+          {
+            title: 'Blog (auf Englisch)',
+            children: utils.getChildren('src', 'blog', true)
           }
         ]
       },
@@ -327,6 +335,10 @@ module.exports = {
           {
             text: 'Instalación',
             link: utils.getNavItemForLanguage(installationNavItem, 'es'),
+          },
+          {
+            text: 'Blog (en inglés)',
+            link: '/blog/',
           },
           {
             text: 'Registro de cambios',
@@ -367,6 +379,10 @@ module.exports = {
           {
             title: 'FAQ',
             children: utils.getNavItemsForLanguage(faqNavItems, "es")
+          },
+          {
+            title: 'Blog (en inglés)',
+            children: utils.getChildren('src', 'blog', true)
           }
         ]
       },
@@ -386,6 +402,10 @@ module.exports = {
           {
             text: 'Telepítés',
             link: utils.getNavItemForLanguage(installationNavItem, 'hu'),
+          },
+          {
+            text: 'Blog (angolul)',
+            link: '/blog/',
           },
           {
             text: 'Változások',
@@ -426,6 +446,10 @@ module.exports = {
           {
             title: 'FAQ',
             children: utils.getNavItemsForLanguage(faqNavItems, "hu")
+          },
+          {
+            title: 'Blog (angolul)',
+            children: utils.getChildren('src', 'blog', true)
           }
         ]
       },
@@ -445,6 +469,10 @@ module.exports = {
           {
             text: 'Installation',
             link: utils.getNavItemForLanguage(installationNavItem, 'fr'),
+          },
+          {
+            text: 'Blog (en anglais)',
+            link: '/blog/',
           },
           {
             text: 'Changelog',
@@ -485,6 +513,10 @@ module.exports = {
           {
             title: 'FAQ',
             children: utils.getNavItemsForLanguage(faqNavItems, "fr")
+          },
+          {
+            title: 'Blog (en anglais)',
+            children: utils.getChildren('src', 'blog', true)
           }
         ]
       },
@@ -504,6 +536,10 @@ module.exports = {
           {
             text: 'Installazione',
             link: utils.getNavItemForLanguage(installationNavItem, 'it'),
+          },
+          {
+            text: 'Blog (in inglese)',
+            link: '/blog/',
           },
           {
             text: 'Log delle modifiche',
@@ -544,6 +580,10 @@ module.exports = {
           {
             title: 'FAQ',
             children: utils.getNavItemsForLanguage(faqNavItems, "it")
+          },
+          {
+            title: 'Blog (in inglese)',
+            children: utils.getChildren('src', 'blog', true)
           }
         ]
       },
@@ -563,6 +603,10 @@ module.exports = {
           {
             text: 'نصب',
             link: utils.getNavItemForLanguage(installationNavItem, 'fa'),
+          },
+          {
+            text: 'وبلاگ (به انگلیسی)',
+            link: '/blog/',
           },
           {
             text: 'گزارش تغییرات',
@@ -603,6 +647,10 @@ module.exports = {
           {
             title: 'سؤالات متداول',
             children: utils.getNavItemsForLanguage(faqNavItems, 'fa')
+          },
+          {
+            title: 'وبلاگ (به انگلیسی)',
+            children: utils.getChildren('src', 'blog', true)
           }
         ]
       },
@@ -622,6 +670,10 @@ module.exports = {
           {
             text: 'Installatie',
             link: utils.getNavItemForLanguage(installationNavItem, 'nl'),
+          },
+          {
+            text: 'Blog (in het Engels)',
+            link: '/blog/',
           },
           {
             text: 'Changelog',
@@ -662,8 +714,13 @@ module.exports = {
           {
             title: 'FAQ',
             children: utils.getNavItemsForLanguage(faqNavItems, "nl")
+          },
+          {
+            title: 'Blog (in het Engels)',
+            children: utils.getChildren('src', 'blog', true)
           }
-        ]      },
+        ]
+      },
       '/ar/': {
         selectText: 'اللغات',
         label: 'العربية',
@@ -681,6 +738,10 @@ module.exports = {
           {
             text: 'التثبيت',
             link: utils.getNavItemForLanguage(installationNavItem, 'ar'),
+          },
+          {
+            text: 'المدونة (بالإنجليزية)',
+            link: '/blog/',
           },
           {
             text: 'سجل التغييرات',
@@ -721,6 +782,10 @@ module.exports = {
           {
             title: 'أسئلة شائعة',
             children: utils.getNavItemsForLanguage(faqNavItems, 'ar')
+          },
+          {
+            title: 'المدونة (بالإنجليزية)',
+            children: utils.getChildren('src', 'blog', true)
           }
         ]
       }

--- a/webpage/src/.vuepress/styles/index.styl
+++ b/webpage/src/.vuepress/styles/index.styl
@@ -83,8 +83,15 @@ html[dir="rtl"]
   .sidebar-heading
     padding-left 0
     padding-right 1.5rem
+
+  .sidebar
+    padding-left 1.5rem
+    padding-right 0
+
+  .sidebar-heading, .sidebar
     .arrow
       right: 0.35em
+      margin-right: 0.35em
     .arrow.right
       transform: rotate(180deg)
 
@@ -120,10 +127,15 @@ html[dir="rtl"]
 
   .sidebar
     left auto !important
-    right 0
+    right 0 !important
     border-right medium none color
     border-left 1px solid $borderColor
     direction rtl
+    transform none
+    transition right 0.5s linear
+
+  .theme-container.no-sidebar:not(.sidebar-open) .sidebar
+    right -100vw !important
 
   a.header-anchor
     float right !important


### PR DESCRIPTION
As discussed in #2494, then in the Telegram/Matrix room ([start [on Matrix]](https://matrix.to/#/!rUzrRvrnrOsLasDdbp:matrix.org/$oqpz48AHfk1tvdjbCw-L1sK3ax4xmcVkHvV-ewtmWlA?via=matrix.org&via=gitter.im&via=ewonchang.com), [end [on Matrix]](https://matrix.to/#/!rUzrRvrnrOsLasDdbp:matrix.org/$RTHMUsM0bUBsEY7kzm2iMiC0UVK0b1gzjz9zmEPJJfk?via=matrix.org&via=gitter.im&via=ewonchang.com)) with the Head of Translation,

This PR add links to the English Blog in the navbar and sidebar in all languages on the website.

The navbar link is a link to the English `/blog/`.

I couldn't make the blog in the sidebar just a link, so I made it identical to the English one: containing "Overview" (in English) and titles of the Blog posts (in English), and clicking on any of them opens it in English.

I did my best to provide the best and most consistent translations for "Blog (in English)" in all languages. A native or fluent speaker is still needed though.