### PR TITLE
Prevent segfault when findAction returns nullptr

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -650,6 +650,10 @@ void MainWindow::initGlobalKeyboardShortcuts() {
         QString actionName = key;
         actionName.remove(QStringLiteral("MainWindow-"));
         QAction *action = findAction(actionName);
+        if (action == nullptr) {
+            qDebug() << "Failed to find action with name: " << actionName;
+            continue;
+        }
         QString shortcut = settings.value(key).toString();
 
         auto hotKey = new QHotkey(QKeySequence(shortcut), true, this);


### PR DESCRIPTION
"Solves" #2528, but the question is: why can't it find the custom action even though I see it in my menu?