### PR TITLE
where for a default time format

### DIFF
--- a/webpage/src/editor/time-formats.md
+++ b/webpage/src/editor/time-formats.md
@@ -3,6 +3,10 @@
 You can use your own time format when inserting the current time into a
 note.
 
+You can use this page to build a personal default time format.
+You can enter that string at _Note_ > _Settings_ > _Editor_ >
+_Insert current time_.
+
 ## Expressions for date
 
 | Expression   | Output                                                        |


### PR DESCRIPTION
This PR affects only file webpage/src/editor/time-formats.md and adds only one paragraph.

The added paragraph tells readers where they should place the result of using this page.

Maybe there's a need to remove the preceding sentence.

If that preceding sentence refers to a syntax useable at other than the menu location my sentence points to, maybe that sentence is fine as it is.