### PR TITLE
Fix various typos

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -163,7 +163,7 @@ jobs:
         # Create AppImage (needs Ubuntu 18.04)
         make INSTALL_ROOT=appdir -j 8 install ; find appdir/
         mkdir -p appdir/usr/languages
-        # mv tranlations to appdir (where QOwnNotes will find them)
+        # mv translations to appdir (where QOwnNotes will find them)
         mv ./languages/*.qm appdir/usr/languages
         wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
         chmod a+x linuxdeployqt-continuous-x86_64.AppImage

--- a/appveyor/unzip.vbs
+++ b/appveyor/unzip.vbs
@@ -27,7 +27,7 @@ If NOT fso.FolderExists(extractTo) Then
    fso.CreateFolder(extractTo)
 End If
 
-' Extract the contants of the zip file.
+' Extract the contents of the zip file.
 set objShell = CreateObject("Shell.Application")
 set FilesInZip = objShell.NameSpace(zipFile).Items()
 objShell.NameSpace(extractTo).CopyHere(FilesInZip)

--- a/docs/scripting/examples/callback.qml
+++ b/docs/scripting/examples/callback.qml
@@ -2,7 +2,7 @@ import QtQml 2.0
 import QOwnNotesTypes 1.0
 
 /**
- * This script is a short example of how to use detatched processes and callbacks
+ * This script is a short example of how to use detached processes and callbacks
  * to relieve the UI thread.
  * Visit http://docs.qownnotes.org/ for more information about scripting
  */

--- a/docs/scripting/examples/note-text-from-5pm-mail.qml
+++ b/docs/scripting/examples/note-text-from-5pm-mail.qml
@@ -62,7 +62,7 @@ QtObject {
         // add the headline of the task
         var text = headline + "\n";
         
-        // add "=" charactes so that the headline is really a headline
+        // add "=" characters so that the headline is really a headline
         for (var i = 0; i < headline.length; i++) {
             text += "=";
         }

--- a/src/dialogs/settingsdialog.ui
+++ b/src/dialogs/settingsdialog.ui
@@ -6554,7 +6554,7 @@ Just test yourself if you get sync conflicts and set a higher value if so.</stri
                    <item row="1" column="1" colspan="6">
                     <widget class="QLabel" name="label_38">
                      <property name="text">
-                      <string>A web socket connetion to this server will be opened to act as bridge between the QOwnNotes web application and the QOwnNotes desktop application.</string>
+                      <string>A web socket connection to this server will be opened to act as bridge between the QOwnNotes web application and the QOwnNotes desktop application.</string>
                      </property>
                      <property name="wordWrap">
                       <bool>true</bool>

--- a/src/entities/script.cpp
+++ b/src/entities/script.cpp
@@ -439,7 +439,7 @@ QString Script::scriptRepositoryPath(bool removeRecursively) const {
 }
 
 /**
- * Checks if the script is a script from the sript repository
+ * Checks if the script is a script from the script repository
  *
  * @return
  */

--- a/src/widgets/qownnotesmarkdowntextedit.cpp
+++ b/src/widgets/qownnotesmarkdowntextedit.cpp
@@ -1215,10 +1215,10 @@ bool QOwnNotesMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
                         if (mainWindow != nullptr) {
                             mainWindow->allowNoteEditing();
                         }
-                        // If the answer is overriden to Yes ("Don't ask again" with "Yes"),
+                        // If the answer is overridden to Yes ("Don't ask again" with "Yes"),
                         // what you type then only enables note editing, but is not typed in
                         // the editor. We need to re-send the event after enabling editing.
-                        // BUT, we should do that only if the msgbox is overriden to Yes,
+                        // BUT, we should do that only if the msgbox is overridden to Yes,
                         // not if manually answered.
                         // You may see: https://github.com/pbek/QOwnNotes/issues/2421
                         // This check is partially copied from utils/gui.cpp showMessage()
@@ -1227,7 +1227,7 @@ bool QOwnNotesMarkdownTextEdit::eventFilter(QObject *obj, QEvent *event) {
                         auto overrideButton = static_cast<QMessageBox::StandardButton>(
                             settings.value(settingsKey, QMessageBox::NoButton).toInt());
                         if (overrideButton == QMessageBox::Yes) {
-                            // overriden to answer yes: re-send the event
+                            // overridden to answer yes: re-send the event
                             return QMarkdownTextEdit::eventFilter(obj, event);
                         }
                     }


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ts,./src/libraries,./webpage/src/??/*,./webpage/yarn.lock,./appveyor/OpenSSL/LICENSE  -L ro,ser`