### PR TITLE
Update debian installation instructions

### DIFF
--- a/webpage/src/installation/debian.md
+++ b/webpage/src/installation/debian.md
@@ -12,8 +12,8 @@ Run the following shell commands to add the repository and install QOwnNotes fro
 
 ```bash
 sudo bash -c "echo 'deb http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Debian_11/ /' >> /etc/apt/sources.list.d/qownnotes.list"
-sudo apt-get update
-sudo apt-get install qownnotes
+sudo apt update
+sudo apt install qownnotes
 ```
 
 ::: tip

--- a/webpage/src/installation/debian.md
+++ b/webpage/src/installation/debian.md
@@ -5,13 +5,18 @@
 Run the following shell commands to trust the repository.
 
 ```bash
-wget http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Debian_11/Release.key -O - | sudo apt-key add -
+SIGNED_BY='/etc/apt/keyrings/qownnotes.gpg'
+sudo mkdir -p "$(dirname "${SIGNED_BY}")"
+curl --silent --show-error --location http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Debian_11/Release.key | gpg --dearmor | sudo tee "${SIGNED_BY}" > /dev/null
+sudo chmod u=rw,go=r "${SIGNED_BY}"
 ```
 
 Run the following shell commands to add the repository and install QOwnNotes from there.
 
 ```bash
-sudo bash -c "echo 'deb http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Debian_11/ /' >> /etc/apt/sources.list.d/qownnotes.list"
+SIGNED_BY='/etc/apt/keyrings/qownnotes.gpg'
+ARCHITECTURE="$(dpkg --print-architecture)"
+echo "deb [arch=${ARCHITECTURE} signed-by=${SIGNED_BY}] http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Debian_11/ /" | sudo tee /etc/apt/sources.list.d/qownnotes.list > /dev/null
 sudo apt update
 sudo apt install qownnotes
 ```


### PR DESCRIPTION
New APT security model allows public keys to be connected only to specific
repositories. This eliminates the problem that any key could be used
in conjunction with any repository, not just the one which distributed
its key.

"[..] The key MUST NOT be placed in /etc/apt/trusted.gpg.d or loaded by apt-key add.
If future updates to the key will be managed by an apt/dpkg package as recommended below,
then it SHOULD be downloaded into /usr/share/keyrings using the same filename
that will be provided by the package. If it will be managed locally ,
it SHOULD be downloaded into /etc/apt/keyrings instead."

[OpenPGP Key Distribution](https://wiki.debian.org/DebianRepository/UseThirdParty#OpenPGP_Key_distribution)

https://manpages.debian.org/bullseye/apt/sources.list.5.en.html
https://wiki.debian.org/DebianRepository/UseThirdParty