### PR TITLE
Qt6: Fix hunspell

### DIFF
--- a/.github/workflows/build-release-qt6.yml
+++ b/.github/workflows/build-release-qt6.yml
@@ -24,7 +24,7 @@ env:
   PUBLISHER: "Patrizio Bekerle"
   REPO_DIR: "/home/runner/work/QOwnNotes"
   QT_VERSION: 6.5.0
-  QT_MODULES: "qtwebsockets"
+  QT_MODULES: "qtwebsockets qt5compat"
   QMAKE: qmake6
   CORES: 16
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -120,7 +120,7 @@ jobs:
         aqtversion: '==2.0.0'
         version: ${{ matrix.qt-version }}
         arch: win64_mingw81
-        modules: qtwebsockets
+        modules: qtwebsockets qt5compat
         cache: ${{ steps.cache-qt.outputs.cache-hit }}
     - if: false == contains( matrix.os, 'windows') && ( matrix.qt-version != '6.2.0' )
       name: Install Qt < 6 on Linux/macOS
@@ -135,7 +135,7 @@ jobs:
       with:
         aqtversion: '==2.0.0'
         version: ${{ matrix.qt-version }}
-        modules: qtwebsockets
+        modules: qtwebsockets qt5compat
         cache: ${{ steps.cache-qt.outputs.cache-hit }}
 
       #

--- a/src/libraries/sonnet/src/plugins/hunspell/hunspell.pri
+++ b/src/libraries/sonnet/src/plugins/hunspell/hunspell.pri
@@ -2,6 +2,9 @@
 #TEMPLATE = lib
 #CONFIG += staticlib
 QT -= gui
+greaterThan(QT_MAJOR_VERSION, 5) {
+    QT += core5compat
+}
 
 include($$PWD/hunspell/hunspell_lib.pri)
 

--- a/src/libraries/sonnet/src/plugins/hunspell/hunspelldict.cpp
+++ b/src/libraries/sonnet/src/plugins/hunspell/hunspelldict.cpp
@@ -32,10 +32,6 @@
 #include <utils/misc.h>
 #include <QStringBuilder>
 
-#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
-#include <QStringEncoder>
-#endif
-
 using namespace Sonnet;
 
 HunspellDict::HunspellDict(const QString &lang, QString path)
@@ -54,21 +50,14 @@ HunspellDict::HunspellDict(const QString &lang, QString path)
 
         m_speller
                 = new Hunspell(aff.toLocal8Bit().constData(), dictionary.toLocal8Bit().constData());
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        m_codec = QStringConverter::encodingForName(m_speller->get_dic_encoding()).value_or(QStringConverter::Utf8);
-#else
+
         m_codec = QTextCodec::codecForName(m_speller->get_dic_encoding());
-#endif
         if (!m_codec) {
             qWarning() << "Failed to find a text codec for name"
                                        << m_speller->get_dic_encoding()
                                        << "defaulting to locale text codec";
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            m_codec = QStringConverter::Utf8;
-#else
             m_codec = QTextCodec::codecForLocale();
             Q_ASSERT(m_codec);
-#endif
         }
 
     } else {
@@ -121,12 +110,7 @@ HunspellDict::~HunspellDict()
 QByteArray HunspellDict::toDictEncoding(const QString &word) const
 {
     if (m_codec) {
-#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
-        QStringEncoder e(m_codec);
-        return e.encode(word);
-#else
         return m_codec->fromUnicode(word);
-#endif
     }
     return {};
 }
@@ -150,17 +134,9 @@ QStringList HunspellDict::suggest(const QString &word) const
 
     QStringList lst;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
-        QStringDecoder e(m_codec);
-        const auto suggestions = m_speller->suggest(toDictEncoding(word).toStdString());
-        std::for_each (suggestions.begin(), suggestions.end(), [&e, &lst](const std::string &suggestion) {
-                lst << e.decode(suggestion.c_str());
-        });
-#else
     const auto suggestions = m_speller->suggest(toDictEncoding(word).toStdString());
     std::for_each (suggestions.begin(), suggestions.end(), [this, &lst](const std::string &suggestion) {
             lst << m_codec->toUnicode(suggestion.c_str()); });
-#endif
 
     return lst;
 }

--- a/src/libraries/sonnet/src/plugins/hunspell/hunspelldict.h
+++ b/src/libraries/sonnet/src/plugins/hunspell/hunspelldict.h
@@ -24,11 +24,7 @@
 #include "spellerplugin_p.h"
 #include "hunspell/src/hunspell/hunspell.hxx"
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-  #include <QStringConverter>
-#else
-  #include <QTextCodec>
-#endif
+#include <QTextCodec>
 
 class HunspellDict : public Sonnet::SpellerPlugin
 {
@@ -48,11 +44,7 @@ private:
     QByteArray toDictEncoding(const QString &word) const;
 
     Hunspell *m_speller = nullptr;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    QStringConverter::Encoding m_codec;
-#else
     QTextCodec *m_codec = nullptr;
-#endif
 };
 
 #endif


### PR DESCRIPTION
Enable core5compat to be able to use QTextCodec. QStringConverter doesn't support many encodings that we need to support all dicts