### PR TITLE
nix: improve nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,16 +1,22 @@
 { pkgs ? import <nixpkgs> {} }:
   pkgs.mkShell {
     # nativeBuildInputs is usually what you want -- tools you need to run
-    nativeBuildInputs = [
-      pkgs.crowdin-cli
-      pkgs.buildPackages.cmakeWithGui
-      pkgs.buildPackages.qt6.qtbase
-      pkgs.buildPackages.qt6.qmake
-      pkgs.buildPackages.qt6.qttools
-      pkgs.buildPackages.qt6.wrapQtAppsHook
-      pkgs.buildPackages.qt6.qtwebsockets
-      pkgs.buildPackages.qt6.qtdeclarative
-      pkgs.buildPackages.qt6.qtsvg
+    nativeBuildInputs = with pkgs; with qt6; [
+      crowdin-cli
+      cmakeWithGui
+      qmake
+      qttools
+      wrapQtAppsHook
+      pkg-config
+    ];
+
+    buildInputs = with pkgs; with qt6; [
+      qtbase
+      qtwebsockets
+      qtdeclarative
+      qtsvg
+      qt5compat
+      botan2
     ];
 }
 


### PR DESCRIPTION
In general though, nativeBuildInputs is useful for cross-compilation as commands from those derivations will be available on the buildPlatform and execute at build time. Whereas buildInputs will likely be the architecture of the hostPlatform, so the derivation can link against those inputs (and be used at run-time).

https://discourse.nixos.org/t/use-buildinputs-or-nativebuildinputs-for-nix-shell/8464

