### PR TITLE
i18n: use qt6 dir for translations when building on qt6

### DIFF
--- a/src/QOwnNotes.pro
+++ b/src/QOwnNotes.pro
@@ -405,7 +405,11 @@ unix {
       desktop.files += PBE.QOwnNotes.desktop
   }
 
-  i18n.path = $$DATADIR/qt5/translations
+  lessThan(QT_MAJOR_VERSION, 6) {
+      i18n.path = $$DATADIR/qt5/translations
+  } else {
+      i18n.path = $$DATADIR/qt6/translations
+  }
   i18n.files += languages/*.qm
 
   icons.path = $$DATADIR/icons/hicolor

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,8 +49,13 @@ void loadTranslations(QTranslator *translator, const QString &locale) {
     loadTranslation(translator[5], appPath + "/languages/QOwnNotes_" + locale);
     loadTranslation(translator[6], appPath + "/QOwnNotes_" + locale);
     loadTranslation(translator[7], "../src/languages/QOwnNotes_" + locale);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    loadTranslation(translator[8], "../share/qt6/translations/QOwnNotes_" + locale);
+    loadTranslation(translator[9], appPath + "/../share/qt6/translations/QOwnNotes_" + locale);
+#else
     loadTranslation(translator[8], "../share/qt5/translations/QOwnNotes_" + locale);
     loadTranslation(translator[9], appPath + "/../share/qt5/translations/QOwnNotes_" + locale);
+#endif
     loadTranslation(translator[10], "QOwnNotes_" + locale);
 }
 
@@ -59,7 +64,11 @@ void loadTranslations(QTranslator *translator, const QString &locale) {
  */
 inline void loadReleaseTranslations(QTranslator &translatorRelease, const QString &locale) {
     loadTranslation(translatorRelease,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+                    "/usr/share/qt6/translations/"
+#else
                     "/usr/share/qt5/translations/"
+#endif
                     "QOwnNotes_" +
                         locale);
 }


### PR DESCRIPTION
hi, i'm working on updating a qownnotes rpm spec to support qt6 and ran into some issues with this hardcoded path.
