### PR TITLE
#2847: Require qtconcurrent for Qt5

### DIFF
--- a/build-systems/gentoo/qownnotes.ebuild
+++ b/build-systems/gentoo/qownnotes.ebuild
@@ -23,6 +23,7 @@ DEPEND="
 	dev-qt/qtwidgets:5
 	dev-qt/qtgui:5
 	dev-qt/qtcore:5
+	dev-qt/qtconcurrent:5
 	dev-qt/qtsql:5
 	dev-qt/qtsvg:5
 	dev-qt/qtnetwork:5


### PR DESCRIPTION
The need for qtconcurrent predates all versions available in the gentoo overlay, so you don't need to push a new release version just for this: I'll go in and submit a PR to that repo to fix those.