### PR TITLE
Add System Verilog syntax highlighting support

### DIFF
--- a/src/helpers/codetohtmlconverter.cpp
+++ b/src/helpers/codetohtmlconverter.cpp
@@ -159,7 +159,7 @@ QString CodeToHtmlConverter::process(StringView input) const {
             ;
             break;
         case CodeSystemVerilog:
-            loadSQLData(types, keywords, builtin, literals, others);
+            loadSystemVerilogData(types, keywords, builtin, literals, others);
             break;
         default:
             output += escapeString(input);

--- a/src/helpers/codetohtmlconverter.cpp
+++ b/src/helpers/codetohtmlconverter.cpp
@@ -50,7 +50,8 @@ void CodeToHtmlConverter::initCodeLangs() Q_DECL_NOTHROW {
         {QStringLiteral("xml"), CodeToHtmlConverter::CodeXML},
         {QStringLiteral("yml"), CodeToHtmlConverter::CodeYAML},
         {QStringLiteral("yaml"), CodeToHtmlConverter::CodeYAML},
-        {QStringLiteral("forth"), CodeToHtmlConverter::CodeForth}};
+        {QStringLiteral("forth"), CodeToHtmlConverter::CodeForth},
+        {QStringLiteral("systemverilog"), CodeToHtmlConverter::CodeSystemVerilog}};
 }
 
 QString CodeToHtmlConverter::process(const QString &input) const {
@@ -156,6 +157,9 @@ QString CodeToHtmlConverter::process(StringView input) const {
             loadForthData(types, keywords, builtin, literals, others);
             comment = QLatin1Char('\\');
             ;
+            break;
+        case CodeSystemVerilog:
+            loadSQLData(types, keywords, builtin, literals, others);
             break;
         default:
             output += escapeString(input);

--- a/src/helpers/codetohtmlconverter.h
+++ b/src/helpers/codetohtmlconverter.h
@@ -50,7 +50,8 @@ class CodeToHtmlConverter {
         CodeCMake,
         CodeMake,
         CodeNix,
-        CodeForth
+        CodeForth,
+        CodeSystemVerilog
     };
 
    public:


### PR DESCRIPTION
I've made a pull request here https://github.com/pbek/qmarkdowntextedit/pull/205 to add support to the submodule. 
I'm not sure if I should update the submodule in this pull request.
~~Also the preview window doesn't seem to work with the highlighting on my local build and I'm not quite sure why, I referred to https://github.com/pbek/QOwnNotes/pull/2782 and can't seem to find what I'm missing~~ this was caused by me loading SQL data by mistake instead of systemverilog