### PR TITLE
Tags support for todos

### DIFF
--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -917,6 +917,10 @@ void TodoDialog::reloadCurrentTags()
     ui->tagCloudLayout->layout()->setSizeConstraint(QLayout::SetFixedSize);
     for (auto tag : _todoTagsList)
     {
+        if (tag.isEmpty())
+        {
+            continue;
+        }
         QPushButton *tagButton = new QPushButton(tag, ui->tagCloudLayout->layout()->widget());
         tagButton->setIcon(QIcon::fromTheme("tag-delete"));
         connect(tagButton, &QPushButton::released, this, [=](){
@@ -931,13 +935,19 @@ void TodoDialog::reloadCurrentTags()
 
 QString TodoDialog::getTagString()
 {
+    // Remove any possible empty items
+    _todoTagsList.removeAll(QString(""));
     return _todoTagsList.join(',');
 }
 
 void TodoDialog::on_tagsLineEdit_returnPressed()
 {
-    _todoTagsList.append(ui->tagsLineEdit->text());
+    auto newTag = ui->tagsLineEdit->text().simplified();
+    if (_todoTagsList.contains(newTag))
+    {
+        return;
+    }
+    _todoTagsList.append(newTag);
     ui->tagsLineEdit->clear();
-    updateCurrentCalendarItemWithFormData();
     reloadCurrentTags();
 }

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -829,7 +829,13 @@ void TodoDialog::on_todoItemTreeWidget_currentItemChanged(QTreeWidgetItem *curre
 
         // Absolute monster of a regexp that checks for possible edge cases like \\,\\ and such
         QRegularExpression nonescapedCommas(R"(((?<!\\),(?!,))|((?<=\\\\),(?=\\\\))|((?<=\\\\),(?=\\)))");
-        _todoTagsList = currentCalendarItem.getTags().split(nonescapedCommas, Qt::SkipEmptyParts);
+
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
+        _todoTagsList = currentCalendarItem.getTags().split(QStringLiteral("."), QString::SkipEmptyParts);
+#else
+        _todoTagsList = currentCalendarItem.getTags().split(QStringLiteral("."), Qt::SkipEmptyParts);
+#endif
+
         reloadCurrentTags();
 
         QDateTime alarmDate = currentCalendarItem.getAlarmDate();

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -901,7 +901,7 @@ void TodoDialog::on_showDueTodayItemsOnlyCheckBox_clicked() {
 
 void TodoDialog::cleanTagButtons(){
     QLayoutItem *child;
-    while ((child = ui->tagCloudLayout->layout()->takeAt( 0 )) != nullptr) {
+    while ((child = ui->tagCloudLayout->takeAt( 0 )) != nullptr) {
         delete child->widget();
         delete child;
     }
@@ -910,26 +910,35 @@ void TodoDialog::cleanTagButtons(){
 void TodoDialog::reloadCurrentTags()
 {
     cleanTagButtons();
+    ui->tagsFrame->setVisible(false);
     if (_todoTagsList.empty())
     {
         return;
     }
-    ui->tagCloudLayout->layout()->setSizeConstraint(QLayout::SetFixedSize);
+    ui->tagCloudLayout->setSizeConstraint(QLayout::SetFixedSize);
+    int tagRow = 0;
+    int tagCol = 0;
     for (auto tag : _todoTagsList)
     {
         if (tag.isEmpty())
         {
             continue;
         }
-        QPushButton *tagButton = new QPushButton(tag, ui->tagCloudLayout->layout()->widget());
+        QPushButton *tagButton = new QPushButton(tag, ui->tagCloudLayout->widget());
         tagButton->setIcon(QIcon::fromTheme("tag-delete"));
         connect(tagButton, &QPushButton::released, this, [=](){
             _todoTagsList.removeOne(tag);
             reloadCurrentTags();
         });
-        ui->tagCloudLayout->layout()->addWidget(tagButton);
+        if (tagCol > 3)
+        {
+            tagCol = 0;
+            tagRow++;
+        }
+        ui->tagCloudLayout->addWidget(tagButton, tagRow, tagCol);
+        tagCol++;
     }
-
+    ui->tagsFrame->setVisible(true);
 }
 
 

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -463,8 +463,6 @@ void TodoDialog::updateCurrentCalendarItemWithFormData() {
     currentCalendarItem.setPriority(priority);
     currentCalendarItem.setSummary(ui->summaryEdit->text());
     currentCalendarItem.setDescription(ui->descriptionEdit->toPlainText());
-    // Clean the last comma
-    ui->tagsLineEdit->setText(ui->tagsLineEdit->text().remove(QRegularExpression(", *$")));
     currentCalendarItem.setTags(getTagString());
     currentCalendarItem.setModified(QDateTime::currentDateTime());
     currentCalendarItem.setAlarmDate(

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -827,8 +827,9 @@ void TodoDialog::on_todoItemTreeWidget_currentItemChanged(QTreeWidgetItem *curre
         ui->summaryEdit->setCursorPosition(0);
         ui->descriptionEdit->setPlainText(currentCalendarItem.getDescription());
 
-        QRegularExpression commaOnly("(?<!\\\\),");
-        _todoTagsList = currentCalendarItem.getTags().split(commaOnly, Qt::SkipEmptyParts);
+
+        QRegularExpression nonescapedCommas(R"((?<!,\\),(?!,))");
+        _todoTagsList = currentCalendarItem.getTags().split(nonescapedCommas, Qt::SkipEmptyParts);
         reloadCurrentTags();
 
         QDateTime alarmDate = currentCalendarItem.getAlarmDate();
@@ -927,8 +928,8 @@ void TodoDialog::reloadCurrentTags()
         {
             continue;
         }
-        // Don't show escaped commas
-        const QString buttonText = QString(tag).replace("\\,",",");
+        // Don't show escaped commas or escaped backslashes
+        const QString buttonText = QString(tag).replace("\\,",",").replace("\\\\","\\");
         QPushButton *tagButton = new QPushButton(buttonText, ui->tagsFrame);
         tagButton->setIcon(QIcon::fromTheme("tag-delete"));
         connect(tagButton, &QPushButton::released, this, [=](){
@@ -962,8 +963,8 @@ void TodoDialog::on_tagsLineEdit_returnPressed()
     {
         return;
     }
-    // Escape the commas in tags
-    _todoTagsList.append(QString(newTag).replace(",","\\,"));
+    // Escape the backslashes and commas in tags
+    _todoTagsList.append(QString(newTag).replace("\\","\\\\").replace(",","\\,"));
     ui->tagsLineEdit->clear();
     reloadCurrentTags();
 }

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -150,6 +150,8 @@ void TodoDialog::setupUi() {
            "from server"));
     connect(clearCacheAction, SIGNAL(triggered()), this, SLOT(clearCacheAndReloadTodoList()));
 
+    connect(ui->tagsLineEdit, &QLineEdit::returnPressed, this, &TodoDialog::on_tagsLineEdit_returnPressed);
+
     ui->reloadTodoListButton->setMenu(reloadMenu);
 }
 
@@ -455,8 +457,7 @@ void TodoDialog::updateCurrentCalendarItemWithFormData() {
     currentCalendarItem.setDescription(ui->descriptionEdit->toPlainText());
     // Clean the last comma
     ui->tagsLineEdit->setText(ui->tagsLineEdit->text().remove(QRegularExpression(", *$")));
-    //TODO remember to uncomment this
-    //currentCalendarItem.setTags(getTagString());
+    currentCalendarItem.setTags(getTagString());
     currentCalendarItem.setModified(QDateTime::currentDateTime());
     currentCalendarItem.setAlarmDate(
         ui->reminderCheckBox->isChecked() ? ui->reminderDateTimeEdit->dateTime() : QDateTime());
@@ -820,6 +821,8 @@ void TodoDialog::on_todoItemTreeWidget_currentItemChanged(QTreeWidgetItem *curre
         ui->summaryEdit->setCursorPosition(0);
         ui->descriptionEdit->setPlainText(currentCalendarItem.getDescription());
 
+        QRegularExpression commaOnly("(?<!\\\\),");
+        _todoTagsList = currentCalendarItem.getTags().split(commaOnly, Qt::SkipEmptyParts);
         reloadCurrentTags();
 
         QDateTime alarmDate = currentCalendarItem.getAlarmDate();
@@ -902,14 +905,11 @@ void TodoDialog::cleanTagButtons(){
         delete child->widget();
         delete child;
     }
-    _todoTagsList.clear();
 }
 
 void TodoDialog::reloadCurrentTags()
 {
     cleanTagButtons();
-    QRegularExpression commaOnly("(?<!\\\\),");
-    _todoTagsList = currentCalendarItem.getTags().split(commaOnly, Qt::SkipEmptyParts);
     if (_todoTagsList.empty())
     {
         return;
@@ -932,4 +932,12 @@ void TodoDialog::reloadCurrentTags()
 QString TodoDialog::getTagString()
 {
     return _todoTagsList.join(',');
+}
+
+void TodoDialog::on_tagsLineEdit_returnPressed()
+{
+    _todoTagsList.append(ui->tagsLineEdit->text());
+    ui->tagsLineEdit->clear();
+    updateCurrentCalendarItemWithFormData();
+    reloadCurrentTags();
 }

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -944,7 +944,7 @@ QString TodoDialog::getTagString()
     // Remove any possible empty items
     _todoTagsList.removeAll(QString(""));
     _todoTagsList.removeAll(QString(" "));
-    return _todoTagsList.join(',').remove(QRegularExpression(", *$"));
+    return _todoTagsList.join(",").remove(QRegularExpression(", *$"));
 }
 
 void TodoDialog::on_tagsLineEdit_returnPressed()

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -927,7 +927,8 @@ void TodoDialog::reloadCurrentTags()
         {
             continue;
         }
-        QPushButton *tagButton = new QPushButton(tag, ui->tagsFrame);
+        // Don't show escaped commas
+        QPushButton *tagButton = new QPushButton(QString(tag).replace("\\,",","), ui->tagsFrame);
         tagButton->setIcon(QIcon::fromTheme("tag-delete"));
         connect(tagButton, &QPushButton::released, this, [=](){
             _todoTagsList.removeOne(tag);
@@ -944,7 +945,13 @@ QString TodoDialog::getTagString()
     // Remove any possible empty items
     _todoTagsList.removeAll(QString(""));
     _todoTagsList.removeAll(QString(" "));
-    return _todoTagsList.join(",").remove(QRegularExpression(", *$"));
+    QString fullTagString;
+    // We can't use regular join since it also joins escaped commas
+    for (const auto &str :_todoTagsList)
+    {
+        fullTagString.append(str + ",");
+    }
+    return fullTagString.remove(QRegularExpression(", *$"));
 }
 
 void TodoDialog::on_tagsLineEdit_returnPressed()
@@ -954,8 +961,8 @@ void TodoDialog::on_tagsLineEdit_returnPressed()
     {
         return;
     }
-    qWarning() << newTag;
-    _todoTagsList.append(newTag);
+    // Escape the commas in tags
+    _todoTagsList.append(QString(newTag).replace(",","\\,"));
     ui->tagsLineEdit->clear();
     reloadCurrentTags();
 }

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -928,7 +928,8 @@ void TodoDialog::reloadCurrentTags()
             continue;
         }
         // Don't show escaped commas
-        QPushButton *tagButton = new QPushButton(QString(tag).replace("\\,",","), ui->tagsFrame);
+        const QString buttonText = QString(tag).replace("\\\\", "\\").replace("\\,",",");
+        QPushButton *tagButton = new QPushButton(buttonText, ui->tagsFrame);
         tagButton->setIcon(QIcon::fromTheme("tag-delete"));
         connect(tagButton, &QPushButton::released, this, [=](){
             _todoTagsList.removeOne(tag);

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -449,6 +449,8 @@ void TodoDialog::updateCurrentCalendarItemWithFormData() {
     currentCalendarItem.setPriority(priority);
     currentCalendarItem.setSummary(ui->summaryEdit->text());
     currentCalendarItem.setDescription(ui->descriptionEdit->toPlainText());
+    // Clean the last comma
+    ui->tagsLineEdit->setText(ui->tagsLineEdit->text().remove(QRegularExpression(", *$")));
     currentCalendarItem.setTags(ui->tagsLineEdit->text());
     currentCalendarItem.setModified(QDateTime::currentDateTime());
     currentCalendarItem.setAlarmDate(

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -46,9 +46,8 @@ TodoDialog::TodoDialog(const QString &taskUid, QWidget *parent)
     }
 
     _todoTagsScrollArea = new QScrollArea(this);
-    _todoTagsScrollArea->setBackgroundRole(QPalette::Dark);
     _todoTagsScrollArea->setWidget(ui->tagsFrame);
-    _todoTagsScrollArea->setMaximumHeight(120);
+    _todoTagsScrollArea->setMaximumHeight(80);
     ui->tagCloudLayout->setSizeConstraint(QLayout::SetFixedSize);
     ui->tagsLayout->addWidget(_todoTagsScrollArea);
     _todoTagsScrollArea->setVisible(false);

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -402,6 +402,7 @@ void TodoDialog::clearTodoList() {
 void TodoDialog::resetEditFrameControls() {
     ui->summaryEdit->setText(QString());
     ui->descriptionEdit->setPlainText(QString());
+    ui->tagsLineEdit->setText(QString());
     ui->prioritySlider->setValue(0);
     ui->reminderCheckBox->setChecked(false);
     ui->reminderDateTimeEdit->hide();
@@ -448,6 +449,7 @@ void TodoDialog::updateCurrentCalendarItemWithFormData() {
     currentCalendarItem.setPriority(priority);
     currentCalendarItem.setSummary(ui->summaryEdit->text());
     currentCalendarItem.setDescription(ui->descriptionEdit->toPlainText());
+    currentCalendarItem.setTags(ui->tagsLineEdit->text());
     currentCalendarItem.setModified(QDateTime::currentDateTime());
     currentCalendarItem.setAlarmDate(
         ui->reminderCheckBox->isChecked() ? ui->reminderDateTimeEdit->dateTime() : QDateTime());
@@ -809,6 +811,7 @@ void TodoDialog::on_todoItemTreeWidget_currentItemChanged(QTreeWidgetItem *curre
         ui->summaryEdit->setText(currentCalendarItem.getSummary());
         ui->summaryEdit->setCursorPosition(0);
         ui->descriptionEdit->setPlainText(currentCalendarItem.getDescription());
+        ui->tagsLineEdit->setText(currentCalendarItem.getTags());
 
         QDateTime alarmDate = currentCalendarItem.getAlarmDate();
         ui->reminderCheckBox->setChecked(alarmDate.isValid());

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -463,7 +463,7 @@ void TodoDialog::updateCurrentCalendarItemWithFormData() {
     currentCalendarItem.setPriority(priority);
     currentCalendarItem.setSummary(ui->summaryEdit->text());
     currentCalendarItem.setDescription(ui->descriptionEdit->toPlainText());
-    currentCalendarItem.setTags(getTagString());
+    currentCalendarItem.setTags(getTagString().toLatin1());
     currentCalendarItem.setModified(QDateTime::currentDateTime());
     currentCalendarItem.setAlarmDate(
         ui->reminderCheckBox->isChecked() ? ui->reminderDateTimeEdit->dateTime() : QDateTime());
@@ -943,7 +943,8 @@ QString TodoDialog::getTagString()
 {
     // Remove any possible empty items
     _todoTagsList.removeAll(QString(""));
-    return _todoTagsList.join(',');
+    _todoTagsList.removeAll(QString(" "));
+    return _todoTagsList.join(',').remove(QRegularExpression(", *$"));
 }
 
 void TodoDialog::on_tagsLineEdit_returnPressed()

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -463,7 +463,7 @@ void TodoDialog::updateCurrentCalendarItemWithFormData() {
     currentCalendarItem.setPriority(priority);
     currentCalendarItem.setSummary(ui->summaryEdit->text());
     currentCalendarItem.setDescription(ui->descriptionEdit->toPlainText());
-    currentCalendarItem.setTags(getTagString().toLatin1());
+    currentCalendarItem.setTags(getTagString());
     currentCalendarItem.setModified(QDateTime::currentDateTime());
     currentCalendarItem.setAlarmDate(
         ui->reminderCheckBox->isChecked() ? ui->reminderDateTimeEdit->dateTime() : QDateTime());
@@ -921,7 +921,7 @@ void TodoDialog::reloadCurrentTags()
     {
         return;
     }
-    for (auto tag : _todoTagsList)
+    for (const auto &tag : _todoTagsList)
     {
         if (tag.isEmpty())
         {
@@ -949,11 +949,12 @@ QString TodoDialog::getTagString()
 
 void TodoDialog::on_tagsLineEdit_returnPressed()
 {
-    auto newTag = ui->tagsLineEdit->text().simplified();
-    if (_todoTagsList.contains(newTag))
+    const auto newTag = ui->tagsLineEdit->text().simplified();
+    if (_todoTagsList.contains(newTag) || newTag.isEmpty())
     {
         return;
     }
+    qWarning() << newTag;
     _todoTagsList.append(newTag);
     ui->tagsLineEdit->clear();
     reloadCurrentTags();

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -44,6 +44,15 @@ TodoDialog::TodoDialog(const QString &taskUid, QWidget *parent)
     if (!taskUid.isEmpty()) {
         jumpToTask(taskUid);
     }
+
+    _todoTagsScrollArea = new QScrollArea(this);
+    _todoTagsScrollArea->setBackgroundRole(QPalette::Dark);
+    _todoTagsScrollArea->setWidget(ui->tagsFrame);
+    _todoTagsScrollArea->setMaximumHeight(120);
+    ui->tagCloudLayout->setSizeConstraint(QLayout::SetFixedSize);
+    ui->tagsLayout->addWidget(_todoTagsScrollArea);
+    _todoTagsScrollArea->setVisible(false);
+
 }
 
 void TodoDialog::updateCalendarItem(CalendarItem item) {
@@ -901,7 +910,7 @@ void TodoDialog::on_showDueTodayItemsOnlyCheckBox_clicked() {
 
 void TodoDialog::cleanTagButtons(){
     QLayoutItem *child;
-    while ((child = ui->tagCloudLayout->takeAt( 0 )) != nullptr) {
+    while ((child = ui->tagsFrame->layout()->takeAt( 0 )) != nullptr) {
         delete child->widget();
         delete child;
     }
@@ -910,35 +919,26 @@ void TodoDialog::cleanTagButtons(){
 void TodoDialog::reloadCurrentTags()
 {
     cleanTagButtons();
-    ui->tagsFrame->setVisible(false);
+    _todoTagsScrollArea->setVisible(false);
     if (_todoTagsList.empty())
     {
         return;
     }
-    ui->tagCloudLayout->setSizeConstraint(QLayout::SetFixedSize);
-    int tagRow = 0;
-    int tagCol = 0;
     for (auto tag : _todoTagsList)
     {
         if (tag.isEmpty())
         {
             continue;
         }
-        QPushButton *tagButton = new QPushButton(tag, ui->tagCloudLayout->widget());
+        QPushButton *tagButton = new QPushButton(tag, ui->tagsFrame);
         tagButton->setIcon(QIcon::fromTheme("tag-delete"));
         connect(tagButton, &QPushButton::released, this, [=](){
             _todoTagsList.removeOne(tag);
             reloadCurrentTags();
         });
-        if (tagCol > 3)
-        {
-            tagCol = 0;
-            tagRow++;
-        }
-        ui->tagCloudLayout->addWidget(tagButton, tagRow, tagCol);
-        tagCol++;
+        ui->tagsFrame->layout()->addWidget(tagButton);
     }
-    ui->tagsFrame->setVisible(true);
+    _todoTagsScrollArea->setVisible(true);
 }
 
 

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -827,8 +827,8 @@ void TodoDialog::on_todoItemTreeWidget_currentItemChanged(QTreeWidgetItem *curre
         ui->summaryEdit->setCursorPosition(0);
         ui->descriptionEdit->setPlainText(currentCalendarItem.getDescription());
 
-
-        QRegularExpression nonescapedCommas(R"((?<!,\\),(?!,))");
+        // Absolute monster of a regexp that checks for possible edge cases like \\,\\ and such
+        QRegularExpression nonescapedCommas(R"(((?<!\\),(?!,))|((?<=\\\\),(?=\\\\))|((?<=\\\\),(?=\\)))");
         _todoTagsList = currentCalendarItem.getTags().split(nonescapedCommas, Qt::SkipEmptyParts);
         reloadCurrentTags();
 

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -928,7 +928,7 @@ void TodoDialog::reloadCurrentTags()
             continue;
         }
         // Don't show escaped commas
-        const QString buttonText = QString(tag).replace("\\\\", "\\").replace("\\,",",");
+        const QString buttonText = QString(tag).replace("\\,",",");
         QPushButton *tagButton = new QPushButton(buttonText, ui->tagsFrame);
         tagButton->setIcon(QIcon::fromTheme("tag-delete"));
         connect(tagButton, &QPushButton::released, this, [=](){

--- a/src/dialogs/tododialog.h
+++ b/src/dialogs/tododialog.h
@@ -73,6 +73,7 @@ class TodoDialog : public MasterDialog {
     void searchInDescriptionTextEdit(QString &str);
     void createNewTodoItem(const QString &name = QLatin1String(""),
                            const QString &relatedUid = QLatin1String(""));
+    void cleanTagButtons();
 
    protected:
     bool eventFilter(QObject *obj, QEvent *event) override;

--- a/src/dialogs/tododialog.h
+++ b/src/dialogs/tododialog.h
@@ -53,6 +53,7 @@ class TodoDialog : public MasterDialog {
     void on_todoItemTreeWidget_itemChanged(QTreeWidgetItem *item, int column);
     void on_todoItemTreeWidget_customContextMenuRequested(QPoint pos);
     void on_showDueTodayItemsOnlyCheckBox_clicked();
+    void on_tagsLineEdit_returnPressed();
 
    private:
     Ui::TodoDialog *ui;

--- a/src/dialogs/tododialog.h
+++ b/src/dialogs/tododialog.h
@@ -61,6 +61,7 @@ class TodoDialog : public MasterDialog {
     CalendarItem lastCreatedCalendarItem;
     QString _jumpToCalendarItemUid;
     bool _setFocusToDescriptionEdit;
+    QStringList _todoTagsList;
     QTreeWidgetItem *firstVisibleTodoItemTreeItem;
     void setupMainSplitter();
     void storeSettings();
@@ -74,6 +75,8 @@ class TodoDialog : public MasterDialog {
     void createNewTodoItem(const QString &name = QLatin1String(""),
                            const QString &relatedUid = QLatin1String(""));
     void cleanTagButtons();
+    void reloadCurrentTags();
+    QString getTagString();
 
    protected:
     bool eventFilter(QObject *obj, QEvent *event) override;

--- a/src/dialogs/tododialog.h
+++ b/src/dialogs/tododialog.h
@@ -1,6 +1,7 @@
 #ifndef TODODIALOG_H
 #define TODODIALOG_H
 
+#include <qscrollarea.h>
 #include <QTreeWidgetItem>
 
 #include "entities/calendaritem.h"
@@ -63,6 +64,7 @@ class TodoDialog : public MasterDialog {
     QString _jumpToCalendarItemUid;
     bool _setFocusToDescriptionEdit;
     QStringList _todoTagsList;
+    QScrollArea *_todoTagsScrollArea;
     QTreeWidgetItem *firstVisibleTodoItemTreeItem;
     void setupMainSplitter();
     void storeSettings();

--- a/src/dialogs/tododialog.ui
+++ b/src/dialogs/tododialog.ui
@@ -353,12 +353,14 @@
               </property>
              </widget>
             </item>
-            <item>
-             <layout class="QGridLayout" name="tagCloudLayout">
-              <property name="sizeConstraint">
-               <enum>QLayout::SetDefaultConstraint</enum>
-              </property>
-             </layout>
+            <item alignment="Qt::AlignLeft|Qt::AlignTop">
+             <widget class="QFrame" name="tagsFrame">
+              <layout class="QHBoxLayout" name="tagCloudLayout">
+               <property name="sizeConstraint">
+                <enum>QLayout::SetMinimumSize</enum>
+               </property>
+              </layout>
+             </widget>
             </item>
            </layout>
           </item>

--- a/src/dialogs/tododialog.ui
+++ b/src/dialogs/tododialog.ui
@@ -146,6 +146,20 @@
             </layout>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="tagsLabel">
+            <property name="text">
+             <string>Tags</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="tagsLineEdit">
+            <property name="placeholderText">
+             <string>Tags are comma separated: tag1,tag2</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
         <item row="0" column="0" colspan="2">

--- a/src/dialogs/tododialog.ui
+++ b/src/dialogs/tododialog.ui
@@ -20,6 +20,129 @@
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="0">
+      <widget class="QFrame" name="selectFrame">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>1</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <layout class="QGridLayout" name="selectLayout">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>1</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item row="3" column="0">
+         <widget class="QProgressBar" name="todoItemLoadingProgressBar">
+          <property name="toolTip">
+           <string>Todo list items are being loaded from the server</string>
+          </property>
+          <property name="value">
+           <number>24</number>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QCheckBox" name="showDueTodayItemsOnlyCheckBox">
+          <property name="toolTip">
+           <string>This doesn't work for sub-items, because they may be hidden by the parent item!</string>
+          </property>
+          <property name="text">
+           <string>Show only items due today</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QFrame" name="frame">
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QCheckBox" name="showCompletedItemsCheckBox">
+             <property name="text">
+              <string>Show completed items</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="reloadTodoListButton">
+             <property name="toolTip">
+              <string>Reload the todo list from server</string>
+             </property>
+             <property name="text">
+              <string>Reload…</string>
+             </property>
+             <property name="icon">
+              <iconset theme="view-refresh" resource="../breeze-qownnotes.qrc">
+               <normaloff>:/icons/breeze-qownnotes/16x16/view-refresh.svg</normaloff>:/icons/breeze-qownnotes/16x16/view-refresh.svg</iconset>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QComboBox" name="todoListSelector">
+          <property name="toolTip">
+           <string>select your todo list</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="TodoItemTreeWidget" name="todoItemTreeWidget">
+          <property name="contextMenuPolicy">
+           <enum>Qt::CustomContextMenu</enum>
+          </property>
+          <property name="dragDropMode">
+           <enum>QAbstractItemView::InternalMove</enum>
+          </property>
+          <property name="sortingEnabled">
+           <bool>true</bool>
+          </property>
+          <column>
+           <property name="text">
+            <string>Summary</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Due date</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLineEdit" name="newItemEdit">
+          <property name="placeholderText">
+           <string>Search or create todo item</string>
+          </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
      <item row="1" column="1">
       <widget class="QFrame" name="editFrame">
        <property name="sizePolicy">
@@ -53,11 +176,73 @@
         <property name="bottomMargin">
          <number>0</number>
         </property>
-        <item row="6" column="0" colspan="2">
-         <widget class="QOwnNotesMarkdownTextEdit" name="descriptionEdit">
-          <property name="readOnly">
-           <bool>false</bool>
+        <item row="10" column="0" colspan="2">
+         <widget class="QFrame" name="horizontalFrame">
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
           </property>
+          <property name="frameShadow">
+           <enum>QFrame::Raised</enum>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QPushButton" name="saveButton">
+             <property name="toolTip">
+              <string>Save the current todo item</string>
+             </property>
+             <property name="text">
+              <string>Save</string>
+             </property>
+             <property name="icon">
+              <iconset theme="document-save" resource="../breeze-qownnotes.qrc">
+               <normaloff>:/icons/breeze-qownnotes/16x16/document-save.svg</normaloff>:/icons/breeze-qownnotes/16x16/document-save.svg</iconset>
+             </property>
+             <property name="shortcut">
+              <string notr="true">Ctrl+S</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="removeButton">
+             <property name="toolTip">
+              <string>Remove the current todo item</string>
+             </property>
+             <property name="text">
+              <string>Remove</string>
+             </property>
+             <property name="icon">
+              <iconset theme="edit-delete" resource="../breeze-qownnotes.qrc">
+               <normaloff>:/icons/breeze-qownnotes/16x16/edit-delete.svg</normaloff>:/icons/breeze-qownnotes/16x16/edit-delete.svg</iconset>
+             </property>
+             <property name="shortcut">
+              <string notr="true">Ctrl+R</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="noteButton">
+             <property name="text">
+              <string>Note…</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../breeze-qownnotes.qrc">
+               <normaloff>:/icons/breeze-qownnotes/16x16/document-new.svg</normaloff>:/icons/breeze-qownnotes/16x16/document-new.svg</iconset>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
         <item row="8" column="0" colspan="2">
@@ -67,6 +252,19 @@
           </property>
           <property name="lineWidth">
            <number>0</number>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0" colspan="2">
+         <widget class="QLineEdit" name="summaryEdit">
+          <property name="readOnly">
+           <bool>false</bool>
+          </property>
+          <property name="placeholderText">
+           <string>Summary</string>
+          </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -146,6 +344,24 @@
             </layout>
            </widget>
           </item>
+          <item row="2" column="1">
+           <layout class="QVBoxLayout" name="tagsLayout">
+            <item>
+             <widget class="QLineEdit" name="tagsLineEdit">
+              <property name="placeholderText">
+               <string>Add new tag</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QGridLayout" name="tagCloudLayout">
+              <property name="sizeConstraint">
+               <enum>QLayout::SetDefaultConstraint</enum>
+              </property>
+             </layout>
+            </item>
+           </layout>
+          </item>
           <item row="2" column="0">
            <widget class="QLabel" name="tagsLabel">
             <property name="text">
@@ -153,217 +369,12 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="tagsLineEdit">
-            <property name="placeholderText">
-             <string>Tags are comma separated: tag1,tag2</string>
-            </property>
-           </widget>
-          </item>
          </layout>
         </item>
-        <item row="0" column="0" colspan="2">
-         <widget class="QLineEdit" name="summaryEdit">
+        <item row="6" column="0" colspan="2">
+         <widget class="QOwnNotesMarkdownTextEdit" name="descriptionEdit">
           <property name="readOnly">
            <bool>false</bool>
-          </property>
-          <property name="placeholderText">
-           <string>Summary</string>
-          </property>
-          <property name="clearButtonEnabled">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="0" colspan="2">
-         <widget class="QFrame" name="horizontalFrame">
-          <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Raised</enum>
-          </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QPushButton" name="saveButton">
-             <property name="toolTip">
-              <string>Save the current todo item</string>
-             </property>
-             <property name="text">
-              <string>Save</string>
-             </property>
-             <property name="icon">
-              <iconset theme="document-save" resource="../breeze-qownnotes.qrc">
-               <normaloff>:/icons/breeze-qownnotes/16x16/document-save.svg</normaloff>:/icons/breeze-qownnotes/16x16/document-save.svg</iconset>
-             </property>
-             <property name="shortcut">
-              <string notr="true">Ctrl+S</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="removeButton">
-             <property name="toolTip">
-              <string>Remove the current todo item</string>
-             </property>
-             <property name="text">
-              <string>Remove</string>
-             </property>
-             <property name="icon">
-              <iconset theme="edit-delete" resource="../breeze-qownnotes.qrc">
-               <normaloff>:/icons/breeze-qownnotes/16x16/edit-delete.svg</normaloff>:/icons/breeze-qownnotes/16x16/edit-delete.svg</iconset>
-             </property>
-             <property name="shortcut">
-              <string notr="true">Ctrl+R</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="noteButton">
-             <property name="text">
-              <string>Note…</string>
-             </property>
-             <property name="icon">
-              <iconset resource="../breeze-qownnotes.qrc">
-               <normaloff>:/icons/breeze-qownnotes/16x16/document-new.svg</normaloff>:/icons/breeze-qownnotes/16x16/document-new.svg</iconset>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QFrame" name="selectFrame">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <layout class="QGridLayout" name="selectLayout">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>1</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item row="0" column="0">
-         <widget class="QLineEdit" name="newItemEdit">
-          <property name="placeholderText">
-           <string>Search or create todo item</string>
-          </property>
-          <property name="clearButtonEnabled">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QFrame" name="frame">
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QCheckBox" name="showCompletedItemsCheckBox">
-             <property name="text">
-              <string>Show completed items</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="reloadTodoListButton">
-             <property name="toolTip">
-              <string>Reload the todo list from server</string>
-             </property>
-             <property name="text">
-              <string>Reload…</string>
-             </property>
-             <property name="icon">
-              <iconset theme="view-refresh" resource="../breeze-qownnotes.qrc">
-               <normaloff>:/icons/breeze-qownnotes/16x16/view-refresh.svg</normaloff>:/icons/breeze-qownnotes/16x16/view-refresh.svg</iconset>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QProgressBar" name="todoItemLoadingProgressBar">
-          <property name="toolTip">
-           <string>Todo list items are being loaded from the server</string>
-          </property>
-          <property name="value">
-           <number>24</number>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="TodoItemTreeWidget" name="todoItemTreeWidget">
-          <property name="contextMenuPolicy">
-           <enum>Qt::CustomContextMenu</enum>
-          </property>
-          <property name="dragDropMode">
-           <enum>QAbstractItemView::InternalMove</enum>
-          </property>
-          <property name="sortingEnabled">
-           <bool>true</bool>
-          </property>
-          <column>
-           <property name="text">
-            <string>Summary</string>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Due date</string>
-           </property>
-          </column>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QComboBox" name="todoListSelector">
-          <property name="toolTip">
-           <string>select your todo list</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QCheckBox" name="showDueTodayItemsOnlyCheckBox">
-          <property name="toolTip">
-           <string>This doesn't work for sub-items, because they may be hidden by the parent item!</string>
-          </property>
-          <property name="text">
-           <string>Show only items due today</string>
           </property>
          </widget>
         </item>

--- a/src/dialogs/tododialog.ui
+++ b/src/dialogs/tododialog.ui
@@ -270,6 +270,18 @@
         </item>
         <item row="1" column="0" colspan="2">
          <layout class="QFormLayout" name="formLayout">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetFixedSize</enum>
+          </property>
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+          </property>
+          <property name="horizontalSpacing">
+           <number>6</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>6</number>
+          </property>
           <item row="0" column="0">
            <widget class="QLabel" name="priorityLabel">
             <property name="text">
@@ -314,7 +326,16 @@
           </item>
           <item row="1" column="1">
            <widget class="QFrame" name="reminderFrame">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <property name="sizeConstraint">
+              <enum>QLayout::SetFixedSize</enum>
+             </property>
              <property name="leftMargin">
               <number>0</number>
              </property>
@@ -344,30 +365,50 @@
             </layout>
            </widget>
           </item>
-          <item row="2" column="1">
-           <layout class="QVBoxLayout" name="tagsLayout">
-            <item>
-             <widget class="QLineEdit" name="tagsLineEdit">
-              <property name="placeholderText">
-               <string>Add new tag</string>
-              </property>
-             </widget>
-            </item>
-            <item alignment="Qt::AlignLeft|Qt::AlignTop">
-             <widget class="QFrame" name="tagsFrame">
-              <property name="frameShape">
-               <enum>QFrame::StyledPanel</enum>
-              </property>
-              <layout class="QHBoxLayout" name="tagCloudLayout"/>
-             </widget>
-            </item>
-           </layout>
-          </item>
           <item row="2" column="0">
            <widget class="QLabel" name="tagsLabel">
             <property name="text">
              <string>Tags</string>
             </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QFrame" name="tagsLayoutFrame">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QVBoxLayout" name="tagsLayout">
+             <item>
+              <widget class="QLineEdit" name="tagsLineEdit">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="placeholderText">
+                <string>Add new tag</string>
+               </property>
+              </widget>
+             </item>
+             <item alignment="Qt::AlignLeft|Qt::AlignTop">
+              <widget class="QFrame" name="tagsFrame">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="frameShape">
+                <enum>QFrame::NoFrame</enum>
+               </property>
+               <layout class="QHBoxLayout" name="tagCloudLayout"/>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>

--- a/src/dialogs/tododialog.ui
+++ b/src/dialogs/tododialog.ui
@@ -355,8 +355,10 @@
             </item>
             <item alignment="Qt::AlignLeft|Qt::AlignTop">
              <widget class="QFrame" name="tagsFrame">
-              <layout class="QGridLayout" name="tagCloudLayout">
-              </layout>
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <layout class="QHBoxLayout" name="tagCloudLayout"/>
              </widget>
             </item>
            </layout>

--- a/src/dialogs/tododialog.ui
+++ b/src/dialogs/tododialog.ui
@@ -355,10 +355,7 @@
             </item>
             <item alignment="Qt::AlignLeft|Qt::AlignTop">
              <widget class="QFrame" name="tagsFrame">
-              <layout class="QHBoxLayout" name="tagCloudLayout">
-               <property name="sizeConstraint">
-                <enum>QLayout::SetMinimumSize</enum>
-               </property>
+              <layout class="QGridLayout" name="tagCloudLayout">
               </layout>
              </widget>
             </item>

--- a/src/entities/calendaritem.cpp
+++ b/src/entities/calendaritem.cpp
@@ -556,7 +556,8 @@ QString CalendarItem::generateNewICSData() {
         icsDataKeyList.removeAll(QStringLiteral("CATEGORIES"));
     }
     else {
-        icsDataHash[QStringLiteral("CATEGORIES")] = tags;
+        // Turn double backslashes into one for categories
+        icsDataHash[QStringLiteral("CATEGORIES")] = tags.replace("\\\\","\\");
     }
     icsDataHash[QStringLiteral("UID")] = uid;
     icsDataHash[QStringLiteral("PRIORITY")] = QString::number(priority);
@@ -616,8 +617,11 @@ QString CalendarItem::generateNewICSData() {
 
         QString line = icsDataHash.value(key);
 
-        // escape "\"s
-        line.replace(QLatin1String("\\"), QLatin1String("\\\\"));
+        // escape "\"s except for categories where they're singular
+        if (key != QStringLiteral("CATEGORIES"))
+        {
+            line.replace(QLatin1String("\\"), QLatin1String("\\\\"));
+        }
         // convert newlines
         line.replace(QLatin1String("\n"), QLatin1String("\\n"));
 
@@ -741,9 +745,9 @@ bool CalendarItem::updateWithICSData(const QString &icsData) {
                       ? icsDataHash[QStringLiteral("DESCRIPTION")]
                       : QString();
 
-    //ignore escaped commas
+    // Turn double backslashes into one for categories
     tags = icsDataHash.contains(QStringLiteral("CATEGORIES"))
-                      ? icsDataHash[QStringLiteral("CATEGORIES")]
+                      ? icsDataHash[QStringLiteral("CATEGORIES")].replace("\\\\","\\")
                       : QString();
 
     priority = icsDataHash.contains(QStringLiteral("PRIORITY"))

--- a/src/entities/calendaritem.cpp
+++ b/src/entities/calendaritem.cpp
@@ -549,7 +549,7 @@ QString CalendarItem::generateNewICSData() {
     // update the icsDataHash
     icsDataHash[QStringLiteral("SUMMARY")] = summary;
     icsDataHash[QStringLiteral("DESCRIPTION")] = description;
-    icsDataHash[QStringLiteral("CATEGORIES")] = this->tags;
+    icsDataHash[QStringLiteral("CATEGORIES")] = tags;
     icsDataHash[QStringLiteral("UID")] = uid;
     icsDataHash[QStringLiteral("PRIORITY")] = QString::number(priority);
     icsDataHash[QStringLiteral("PERCENT-COMPLETE")] = QString::number(completed ? 100 : 0);
@@ -733,8 +733,9 @@ bool CalendarItem::updateWithICSData(const QString &icsData) {
                       ? icsDataHash[QStringLiteral("DESCRIPTION")]
                       : QString();
 
-    this->tags = icsDataHash.contains(QStringLiteral("CATEGORIES"))
-                      ? icsDataHash[QStringLiteral("CATEGORIES")]
+    //ignore escaped commas
+    tags = icsDataHash.contains(QStringLiteral("CATEGORIES"))
+                      ? icsDataHash[QStringLiteral("CATEGORIES")].toLatin1()
                       : QString();
 
     priority = icsDataHash.contains(QStringLiteral("PRIORITY"))

--- a/src/entities/calendaritem.cpp
+++ b/src/entities/calendaritem.cpp
@@ -1,5 +1,6 @@
 #include "calendaritem.h"
 
+#include <qregularexpression.h>
 #include <services/owncloudservice.h>
 #include <utils/misc.h>
 
@@ -557,7 +558,7 @@ QString CalendarItem::generateNewICSData() {
     }
     else {
         // Turn double backslashes into one for categories
-        icsDataHash[QStringLiteral("CATEGORIES")] = tags.replace("\\\\","\\");
+        icsDataHash[QStringLiteral("CATEGORIES")] = tags;
     }
     icsDataHash[QStringLiteral("UID")] = uid;
     icsDataHash[QStringLiteral("PRIORITY")] = QString::number(priority);
@@ -617,10 +618,11 @@ QString CalendarItem::generateNewICSData() {
 
         QString line = icsDataHash.value(key);
 
-        // escape "\"s except for categories where they're singular
-        if (key != QStringLiteral("CATEGORIES"))
+        // commas only have one backslash
+        line.replace(QRegularExpression("\\"), QLatin1String("\\\\"));
+        if (key == QStringLiteral("CATEGORIES"))
         {
-            line.replace(QLatin1String("\\"), QLatin1String("\\\\"));
+            line.replace(QLatin1String("\\\\,"), QLatin1String("\\,"));
         }
         // convert newlines
         line.replace(QLatin1String("\n"), QLatin1String("\\n"));
@@ -747,7 +749,7 @@ bool CalendarItem::updateWithICSData(const QString &icsData) {
 
     // Turn double backslashes into one for categories
     tags = icsDataHash.contains(QStringLiteral("CATEGORIES"))
-                      ? icsDataHash[QStringLiteral("CATEGORIES")].replace("\\\\","\\")
+                      ? icsDataHash[QStringLiteral("CATEGORIES")]
                       : QString();
 
     priority = icsDataHash.contains(QStringLiteral("PRIORITY"))

--- a/src/entities/calendaritem.cpp
+++ b/src/entities/calendaritem.cpp
@@ -621,8 +621,7 @@ QString CalendarItem::generateNewICSData() {
         // commas only have one backslash
         if (key != QStringLiteral("CATEGORIES"))
         {
-            //line.replace(QLatin1String("\\\\,"), QLatin1String("\\,"));
-            line.replace(QRegularExpression("\\"), QLatin1String("\\\\"));
+            line.replace(QLatin1String("\\"), QLatin1String("\\\\"));
         }
         // convert newlines
         line.replace(QLatin1String("\n"), QLatin1String("\\n"));

--- a/src/entities/calendaritem.cpp
+++ b/src/entities/calendaritem.cpp
@@ -557,8 +557,8 @@ QString CalendarItem::generateNewICSData() {
         icsDataKeyList.removeAll(QStringLiteral("CATEGORIES"));
     }
     else {
-        // Turn double backslashes into one for categories
-        icsDataHash[QStringLiteral("CATEGORIES")] = tags;
+        // Turn single backslashes into two for categories when uploading
+        icsDataHash[QStringLiteral("CATEGORIES")] = tags.replace("\\", "\\\\");
     }
     icsDataHash[QStringLiteral("UID")] = uid;
     icsDataHash[QStringLiteral("PRIORITY")] = QString::number(priority);
@@ -749,7 +749,7 @@ bool CalendarItem::updateWithICSData(const QString &icsData) {
 
     // Turn double backslashes into one for categories
     tags = icsDataHash.contains(QStringLiteral("CATEGORIES"))
-                      ? icsDataHash[QStringLiteral("CATEGORIES")]
+                      ? icsDataHash[QStringLiteral("CATEGORIES")].replace("\\\\", "\\")
                       : QString();
 
     priority = icsDataHash.contains(QStringLiteral("PRIORITY"))

--- a/src/entities/calendaritem.cpp
+++ b/src/entities/calendaritem.cpp
@@ -558,7 +558,7 @@ QString CalendarItem::generateNewICSData() {
     }
     else {
         // Turn single backslashes into two for categories when uploading
-        icsDataHash[QStringLiteral("CATEGORIES")] = tags.replace("\\", "\\\\");
+        icsDataHash[QStringLiteral("CATEGORIES")] = tags;
     }
     icsDataHash[QStringLiteral("UID")] = uid;
     icsDataHash[QStringLiteral("PRIORITY")] = QString::number(priority);
@@ -619,10 +619,10 @@ QString CalendarItem::generateNewICSData() {
         QString line = icsDataHash.value(key);
 
         // commas only have one backslash
-        line.replace(QRegularExpression("\\"), QLatin1String("\\\\"));
-        if (key == QStringLiteral("CATEGORIES"))
+        if (key != QStringLiteral("CATEGORIES"))
         {
-            line.replace(QLatin1String("\\\\,"), QLatin1String("\\,"));
+            //line.replace(QLatin1String("\\\\,"), QLatin1String("\\,"));
+            line.replace(QRegularExpression("\\"), QLatin1String("\\\\"));
         }
         // convert newlines
         line.replace(QLatin1String("\n"), QLatin1String("\\n"));
@@ -749,7 +749,7 @@ bool CalendarItem::updateWithICSData(const QString &icsData) {
 
     // Turn double backslashes into one for categories
     tags = icsDataHash.contains(QStringLiteral("CATEGORIES"))
-                      ? icsDataHash[QStringLiteral("CATEGORIES")].replace("\\\\", "\\")
+                      ? icsDataHash[QStringLiteral("CATEGORIES")]
                       : QString();
 
     priority = icsDataHash.contains(QStringLiteral("PRIORITY"))

--- a/src/entities/calendaritem.cpp
+++ b/src/entities/calendaritem.cpp
@@ -549,7 +549,15 @@ QString CalendarItem::generateNewICSData() {
     // update the icsDataHash
     icsDataHash[QStringLiteral("SUMMARY")] = summary;
     icsDataHash[QStringLiteral("DESCRIPTION")] = description;
-    icsDataHash[QStringLiteral("CATEGORIES")] = tags;
+    // If categories are empty, remove the CATEGORIES data
+    // otherwise we get empty tag
+    if (tags.isEmpty()) {
+        icsDataHash.remove(QStringLiteral("CATEGORIES"));
+        icsDataKeyList.removeAll(QStringLiteral("CATEGORIES"));
+    }
+    else {
+        icsDataHash[QStringLiteral("CATEGORIES")] = tags;
+    }
     icsDataHash[QStringLiteral("UID")] = uid;
     icsDataHash[QStringLiteral("PRIORITY")] = QString::number(priority);
     icsDataHash[QStringLiteral("PERCENT-COMPLETE")] = QString::number(completed ? 100 : 0);

--- a/src/entities/calendaritem.cpp
+++ b/src/entities/calendaritem.cpp
@@ -966,7 +966,15 @@ void CalendarItem::generateICSDataHash() {
             lastKey = findFreeHashKey(&icsDataHash, lastKey);
 
             // add new key / value pair to the hash
-            icsDataHash[lastKey] = decodeICSDataLine(match.captured(2));
+            // Categories/tags wont be cleaned since they can have commas in middle of
+            // a category
+            if (lastKey == "CATEGORIES")
+            {
+                icsDataHash[lastKey] = match.captured(2);
+            }
+            else {
+                icsDataHash[lastKey] = decodeICSDataLine(match.captured(2));
+            }
             //            hash.insert( lastKey, decodeICSDataLine(
             //            match.captured(2) ) );
 

--- a/src/entities/calendaritem.cpp
+++ b/src/entities/calendaritem.cpp
@@ -743,7 +743,7 @@ bool CalendarItem::updateWithICSData(const QString &icsData) {
 
     //ignore escaped commas
     tags = icsDataHash.contains(QStringLiteral("CATEGORIES"))
-                      ? icsDataHash[QStringLiteral("CATEGORIES")].toLatin1()
+                      ? icsDataHash[QStringLiteral("CATEGORIES")]
                       : QString();
 
     priority = icsDataHash.contains(QStringLiteral("PRIORITY"))

--- a/src/entities/calendaritem.h
+++ b/src/entities/calendaritem.h
@@ -37,6 +37,7 @@ class CalendarItem {
     QString getCalendar();
     QString getSummary();
     QString getDescription();
+    QString getTags();
     void setSummary(const QString &text);
     void setDescription(const QString &text);
     bool updateWithICSData(const QString &icsData);
@@ -63,6 +64,7 @@ class CalendarItem {
     void setModified(const QDateTime &dateTime);
     void setCreated(const QDateTime &dateTime);
     void setCompleted(bool value);
+    void setTags(QString tags);
     void updateCompleted(bool value);
     static QList<CalendarItem> fetchAll();
     static void updateAllSortPriorities();
@@ -92,6 +94,7 @@ class CalendarItem {
     int sortPriority;
     bool hasDirtyData;
     bool completed;
+    QString tags;
     QDateTime alarmDate;
     QDateTime created;
     QDateTime modified;

--- a/src/services/databaseservice.cpp
+++ b/src/services/databaseservice.cpp
@@ -877,7 +877,7 @@ bool DatabaseService::setupTables() {
     }
 
     if (version < 42) {
-        queryDisk.exec(QStringLiteral("ALTER TABLE calendarItem ADD tags VARCHAR(255)"));
+        queryDisk.exec(QStringLiteral("ALTER TABLE calendarItem ADD tags VARCHAR(512)"));
         version = 42;
     }
 

--- a/src/services/databaseservice.cpp
+++ b/src/services/databaseservice.cpp
@@ -876,6 +876,11 @@ bool DatabaseService::setupTables() {
         version = 41;
     }
 
+    if (version < 42) {
+        queryDisk.exec(QStringLiteral("ALTER TABLE calendarItem ADD tags VARCHAR(255)"));
+        version = 42;
+    }
+
     if (version != oldVersion) {
         setAppData(QStringLiteral("database_version"), QString::number(version));
     }


### PR DESCRIPTION
As per discussion in https://github.com/pbek/QOwnNotes/issues/2998#issuecomment-2054165209

This adds a very simple input field to the todo items list, with comma delimited tags support.

![322305792-3d989136-8d73-408d-85b7-807f1cb15b29](https://github.com/pbek/QOwnNotes/assets/13801236/4b6ccb54-b1df-4ef9-9f5b-40bbf6589a2d)

Tags can be any text and they're separated with `,`. If user leaves a `,` in the end of the string, it will be cleaned from the input when saving.

I am personally fine with just comma limited input field for this :)