### PR TITLE
Fix accidental typo with dot that should be comma

### DIFF
--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -833,10 +833,10 @@ void TodoDialog::on_todoItemTreeWidget_currentItemChanged(QTreeWidgetItem *curre
 
 #if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
         _todoTagsList =
-            currentCalendarItem.getTags().split(QStringLiteral("."), QString::SkipEmptyParts);
+            currentCalendarItem.getTags().split(QStringLiteral(","), QString::SkipEmptyParts);
 #else
         _todoTagsList =
-            currentCalendarItem.getTags().split(QStringLiteral("."), Qt::SkipEmptyParts);
+            currentCalendarItem.getTags().split(QStringLiteral(","), Qt::SkipEmptyParts);
 #endif
 
         reloadCurrentTags();


### PR DESCRIPTION
This fixes the accidental typo where the dots should have been commas instead. 

https://github.com/pbek/QOwnNotes/issues/2998#issuecomment-2073292685

