### PR TITLE
fix: update NixOS wiki link

### DIFF
--- a/webpage/src/ar/installation/macos.md
+++ b/webpage/src/ar/installation/macos.md
@@ -20,4 +20,4 @@ brew install qownnotes
 
 ## Nix
 
-You can also install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).
+You can also install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).

--- a/webpage/src/ar/installation/nix.md
+++ b/webpage/src/ar/installation/nix.md
@@ -1,6 +1,6 @@
 # التثبيت عبر Nix
 
-يمكنك تثبيت QOwnNotes باستخدام [مدير الحزم Nix](https://nixos.wiki/wiki/Nix_package_manager) على [NixOS](https://nixos.org/) والمنصات الأخرى؛ اسم الحزمة هو [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
+يمكنك تثبيت QOwnNotes باستخدام [مدير الحزم Nix](https://wiki.nixos.org/wiki/Nix_package_manager) على [NixOS](https://nixos.org/) والمنصات الأخرى؛ اسم الحزمة هو [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 
 انظر [QOwnNotes على nix](https://search.nixos.org/packages?channel=unstable&show=qownnotes) للمزيد من المعلومات.
 

--- a/webpage/src/de/installation/macos.md
+++ b/webpage/src/de/installation/macos.md
@@ -20,4 +20,4 @@ brew install qownnotes
 
 ## Nix
 
-You can also install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).
+You can also install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).

--- a/webpage/src/de/installation/nix.md
+++ b/webpage/src/de/installation/nix.md
@@ -1,6 +1,6 @@
 # Installation mit Nix
 
-Sie können QOwnNotes mit dem [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) auf [NixOS](https://nixos.org/) und anderen Plattformen installieren. Das Paket heißt [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
+Sie können QOwnNotes mit dem [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) auf [NixOS](https://nixos.org/) und anderen Plattformen installieren. Das Paket heißt [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 
 Mehr Informationen auf [QOwnNotes auf Nix](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 

--- a/webpage/src/es/installation/macos.md
+++ b/webpage/src/es/installation/macos.md
@@ -20,4 +20,4 @@ brew install qownnotes
 
 ## Nix
 
-You can also install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).
+You can also install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).

--- a/webpage/src/es/installation/nix.md
+++ b/webpage/src/es/installation/nix.md
@@ -1,6 +1,6 @@
 # Install via Nix
 
-Puedes instalar QOwnNotes con el [gestor de paquetes de Nix](https://nixos.wiki/wiki/Nix_package_manager) en [NixOS](https://nixos.org/) y otras plataformas, el nombre del paquete es [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
+Puedes instalar QOwnNotes con el [gestor de paquetes de Nix](https://wiki.nixos.org/wiki/Nix_package_manager) en [NixOS](https://nixos.org/) y otras plataformas, el nombre del paquete es [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 
 Para mayor información mira [QOwnNotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 

--- a/webpage/src/fa/installation/macos.md
+++ b/webpage/src/fa/installation/macos.md
@@ -20,4 +20,4 @@ brew install qownnotes
 
 ## Nix
 
-You can also install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).
+You can also install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).

--- a/webpage/src/fa/installation/nix.md
+++ b/webpage/src/fa/installation/nix.md
@@ -1,6 +1,6 @@
 # Install via Nix
 
-You can install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) on [NixOS](https://nixos.org/) and other platforms, the package name is [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
+You can install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) on [NixOS](https://nixos.org/) and other platforms, the package name is [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 
 See [QOwnNotes on nix](https://search.nixos.org/packages?channel=unstable&show=qownnotes) for more information.
 

--- a/webpage/src/fr/installation/macos.md
+++ b/webpage/src/fr/installation/macos.md
@@ -20,4 +20,4 @@ brew install qownnotes
 
 ## Nix
 
-You can also install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).
+You can also install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).

--- a/webpage/src/fr/installation/nix.md
+++ b/webpage/src/fr/installation/nix.md
@@ -1,6 +1,6 @@
 # Install via Nix
 
-You can install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) on [NixOS](https://nixos.org/) and other platforms, the package name is [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
+You can install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) on [NixOS](https://nixos.org/) and other platforms, the package name is [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 
 See [QOwnNotes on nix](https://search.nixos.org/packages?channel=unstable&show=qownnotes) for more information.
 

--- a/webpage/src/hu/installation/macos.md
+++ b/webpage/src/hu/installation/macos.md
@@ -20,4 +20,4 @@ brew install qownnotes
 
 ## Nix
 
-You can also install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).
+You can also install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).

--- a/webpage/src/hu/installation/nix.md
+++ b/webpage/src/hu/installation/nix.md
@@ -1,6 +1,6 @@
 # Install via Nix
 
-You can install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) on [NixOS](https://nixos.org/) and other platforms, the package name is [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
+You can install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) on [NixOS](https://nixos.org/) and other platforms, the package name is [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 
 See [QOwnNotes on nix](https://search.nixos.org/packages?channel=unstable&show=qownnotes) for more information.
 

--- a/webpage/src/installation/macos.md
+++ b/webpage/src/installation/macos.md
@@ -22,5 +22,5 @@ brew install qownnotes
 
 ## Nix
 
-You can also install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager)
+You can also install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager)
 under macOS, see [Install via Nix](./nix.md).

--- a/webpage/src/installation/nix.md
+++ b/webpage/src/installation/nix.md
@@ -1,6 +1,6 @@
 # Install via Nix
 
-You can install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager)
+You can install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager)
 on [NixOS](https://nixos.org/) and other platforms, the package name is
 [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 

--- a/webpage/src/it/installation/macos.md
+++ b/webpage/src/it/installation/macos.md
@@ -20,4 +20,4 @@ brew install qownnotes
 
 ## Nix
 
-You can also install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).
+You can also install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).

--- a/webpage/src/it/installation/nix.md
+++ b/webpage/src/it/installation/nix.md
@@ -1,6 +1,6 @@
 # Install via Nix
 
-You can install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) on [NixOS](https://nixos.org/) and other platforms, the package name is [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
+You can install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) on [NixOS](https://nixos.org/) and other platforms, the package name is [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 
 See [QOwnNotes on nix](https://search.nixos.org/packages?channel=unstable&show=qownnotes) for more information.
 

--- a/webpage/src/ko/installation/macos.md
+++ b/webpage/src/ko/installation/macos.md
@@ -18,4 +18,4 @@ brew install qownnotes
 
 ## Nix
 
-You can also install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).
+You can also install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).

--- a/webpage/src/ko/installation/nix.md
+++ b/webpage/src/ko/installation/nix.md
@@ -1,6 +1,6 @@
 # Nix를 통해 설치
 
-[NixOS](https://nixos.org/) 및 기타 플랫폼에서 [Nix 패키지 관리자](https://nixos.wiki/wiki/Nix_package_manager)와 함께 QOnNotes를 설치할 수 있으며 패키지 이름은 [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes)입니다.
+[NixOS](https://nixos.org/) 및 기타 플랫폼에서 [Nix 패키지 관리자](https://wiki.nixos.org/wiki/Nix_package_manager)와 함께 QOnNotes를 설치할 수 있으며 패키지 이름은 [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes)입니다.
 
 자세한 내용은 [nix의 QOwnNotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes)를 참조하십시오.
 

--- a/webpage/src/nl/installation/macos.md
+++ b/webpage/src/nl/installation/macos.md
@@ -19,4 +19,4 @@ brew install qownnotes
 
 ## Nix
 
-You can also install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).
+You can also install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).

--- a/webpage/src/nl/installation/nix.md
+++ b/webpage/src/nl/installation/nix.md
@@ -1,6 +1,6 @@
 # Installatie via Nix
 
-U kunt QOwnNotes installeren met de [Nix pakketbeheerder](https://nixos.wiki/wiki/Nix_package_manager) op [NixOS](https://nixos.org/) en andere platforms is de pakketnaam [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
+U kunt QOwnNotes installeren met de [Nix pakketbeheerder](https://wiki.nixos.org/wiki/Nix_package_manager) op [NixOS](https://nixos.org/) en andere platforms is de pakketnaam [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 
 Zie [QOwnNotes op nix](https://search.nixos.org/packages?channel=unstable&show=qownnotes) voor meer informatie.
 

--- a/webpage/src/pl/installation/macos.md
+++ b/webpage/src/pl/installation/macos.md
@@ -20,4 +20,4 @@ brew install qownnotes
 
 ## Nix
 
-You can also install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).
+You can also install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) under macOS, see [Install via Nix](./nix.md).

--- a/webpage/src/pl/installation/nix.md
+++ b/webpage/src/pl/installation/nix.md
@@ -1,6 +1,6 @@
 # Install via Nix
 
-You can install QOwnNotes with the [Nix package manager](https://nixos.wiki/wiki/Nix_package_manager) on [NixOS](https://nixos.org/) and other platforms, the package name is [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
+You can install QOwnNotes with the [Nix package manager](https://wiki.nixos.org/wiki/Nix_package_manager) on [NixOS](https://nixos.org/) and other platforms, the package name is [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 
 See [QOwnNotes on nix](https://search.nixos.org/packages?channel=unstable&show=qownnotes) for more information.
 


### PR DESCRIPTION
Hello!

This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: NixOS/foundation#113