### PR TITLE
Create clickable sha256 file for QownNotes.zip

### DIFF
--- a/.github/workflows/build-release-qt6.yml
+++ b/.github/workflows/build-release-qt6.yml
@@ -310,8 +310,8 @@ jobs:
       - name: '📤 Upload artifact: Windows clickable sha256sum'
         uses: actions/upload-artifact@v4
         with:
-          name: QOwnNotes.zip.clickable.sha256
-          path: QOwnNotes.zip.clickable.sha256
+          name: QOwnNotes.zip.sha256sum
+          path: QOwnNotes.zip.sha256sum
 
 #      - name: '📤 Release ZIP'
 #        uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-release-qt6.yml
+++ b/.github/workflows/build-release-qt6.yml
@@ -307,6 +307,11 @@ jobs:
         with:
           name: QOwnNotes.zip.sha256
           path: QOwnNotes.zip.sha256
+      - name: '📤 Upload artifact: Windows clickable sha256sum'
+        uses: actions/upload-artifact@v4
+        with:
+          name: QOwnNotes.zip.clickable.sha256
+          path: QOwnNotes.zip.clickable.sha256
 
 #      - name: '📤 Release ZIP'
 #        uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -302,6 +302,16 @@ jobs:
           asset_path: QOwnNotes.zip.sha256
           asset_name: QOwnNotes.zip.sha256
           asset_content_type: text/plain
+      - name: '📤 Release clickable sha256 sum'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: QOwnNotes.zip.clickable.sha256
+          asset_name: QOwnNotes.zip.clickable.sha256
+          asset_content_type: text/plain
+
 
 
   #

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -308,8 +308,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: QOwnNotes.zip.clickable.sha256
-          asset_name: QOwnNotes.zip.clickable.sha256
+          asset_path: QOwnNotes.zip.sha256sum
+          asset_name: QOwnNotes.zip.sha256sum
           asset_content_type: text/plain
 
 

--- a/build-systems/github/windows/build-zip-qt6.ps1
+++ b/build-systems/github/windows/build-zip-qt6.ps1
@@ -46,7 +46,7 @@ Get-ChildItem D:\a\QOwnNotes\QOwnNotes\release
 tree D:\a\QOwnNotes\QOwnNotes\release
 Compress-Archive -Path * -DestinationPath ..\QOwnNotes.zip
 # Get sha256 checksum
-$Checksum = [string] (Get-FileHash -Path '..\QOwnNotes.zip' -Algorithm 'SHA256').'Hash'.ToLower().Trim()
+$Checksum = [string] (Get-FileHash -Path '..\QOwnNotes.zip' -Algorithm 'SHA256').'Hash'.ToLower()
 # Create sha256 file with checksum only
 Out-File -FilePath '..\QOwnNotes.zip.sha256' -Encoding 'utf8' -InputObject $Checksum
 # Create sha256 file with name of file

--- a/build-systems/github/windows/build-zip-qt6.ps1
+++ b/build-systems/github/windows/build-zip-qt6.ps1
@@ -7,41 +7,52 @@ $ErrorActionPreference = "Stop"
 
 #dir -s ..\..\Qt
 Write-Host $Env:QT_VERSION
-echo "#define RELEASE ""GitHub Actions""" > release.h
+Write-Output "#define RELEASE ""GitHub Actions""" > release.h
 qmake6 QOwnNotes.pro -r
 lrelease QOwnNotes.pro
 make
-md ..\release
+# Create release directory
+New-Item -Path '..\release' -ItemType 'Directory'
 # copy the binary to our release path
-copy release\QOwnNotes.exe ..\release
+Copy-Item release\QOwnNotes.exe ..\release
 # copy Win64 OpenSSL v1.1.1g DLLs to the release path
-copy ..\build-systems\github\windows\libcrypto-1_1-x64.dll ..\release
-copy ..\build-systems\github\windows\libssl-1_1-x64.dll ..\release
+Copy-Item ..\build-systems\github\windows\libcrypto-1_1-x64.dll ..\release
+Copy-Item ..\build-systems\github\windows\libssl-1_1-x64.dll ..\release
 # copy unzip application for updater
-copy ..\appveyor\unzip.exe ..\release
+Copy-Item ..\appveyor\unzip.exe ..\release
 # copy updater script
-copy ..\appveyor\update.bat ..\release
+Copy-Item ..\appveyor\update.bat ..\release
 # copy portable mode launcher to the release path
-copy ..\appveyor\QOwnNotesPortable.bat ..\release
+Copy-Item ..\appveyor\QOwnNotesPortable.bat ..\release
 # copy translation files
-copy languages\*.qm ..\release
-cd ..\release
+Copy-Item languages\*.qm ..\release
+Set-Location ..\release
 # fetching dependencies of QT app
 # http://doc.qt.io/qt-5/windows-deployment.html
 # Bug in Qt 5.14+: https://stackoverflow.com/questions/61045959/windeployqt-error-unable-to-find-the-platform-plugin
 # Don't use "--release"! (maybe because of debug log?)
 windeployqt --debug QOwnNotes.exe
 # these dlls where missed by windeployqt
-copy ..\..\Qt\$Env:QT_VERSION\mingw_64\bin\libwinpthread-1.dll .
-copy ..\..\Qt\$Env:QT_VERSION\mingw_64\bin\libgcc_s_seh-1.dll .
+Copy-Item ..\..\Qt\$Env:QT_VERSION\mingw_64\bin\libwinpthread-1.dll .
+Copy-Item ..\..\Qt\$Env:QT_VERSION\mingw_64\bin\libgcc_s_seh-1.dll .
 # this dll didn't work when released by windeployqt
 # important: this dll needs to be updated when a new version of Qt is used!
 # search for it in the mingw* folder of your local installation of Qt
 # Update: we are trying a direct copy again
-copy ..\..\Qt\$Env:QT_VERSION\mingw_64\bin\libstdc++-6.dll .
-# create zip archive
-dir
-dir D:\a\QOwnNotes\QOwnNotes\release
+Copy-Item ..\..\Qt\$Env:QT_VERSION\mingw_64\bin\libstdc++-6.dll .
+# Create zip archive
+Get-ChildItem
+Get-ChildItem D:\a\QOwnNotes\QOwnNotes\release
 tree D:\a\QOwnNotes\QOwnNotes\release
 Compress-Archive -Path * -DestinationPath ..\QOwnNotes.zip
-$(CertUtil -hashfile ..\QOwnNotes.zip SHA256)[1] -replace " ","" | Out-File -FilePath ..\QOwnNotes.zip.sha256
+# Get sha256 checksum
+$Checksum = [string] (Get-FileHash -Path '..\QOwnNotes.zip' -Algorithm 'SHA256').'Hash'.ToLower().Trim()
+# Create sha256 file with checksum only
+Out-File -FilePath '..\QOwnNotes.zip.sha256' -Encoding 'utf8' -InputObject $Checksum
+# Create sha256 file with name of file
+Out-File -FilePath '..\QOwnNotes.zip.clickable.sha256' -Encoding 'utf8' -InputObject (
+    [string]::Format(
+        '{0} *QOwnNotes.zip',
+        $Checksum
+    )
+)

--- a/build-systems/github/windows/build-zip-qt6.ps1
+++ b/build-systems/github/windows/build-zip-qt6.ps1
@@ -50,7 +50,7 @@ $Checksum = [string] (Get-FileHash -Path '..\QOwnNotes.zip' -Algorithm 'SHA256')
 # Create sha256 file with checksum only
 Out-File -FilePath '..\QOwnNotes.zip.sha256' -Encoding 'utf8' -InputObject $Checksum
 # Create sha256 file with name of file
-Out-File -FilePath '..\QOwnNotes.zip.clickable.sha256' -Encoding 'utf8' -InputObject (
+Out-File -FilePath '..\QOwnNotes.zip.sha256sum' -Encoding 'utf8' -InputObject (
     [string]::Format(
         '{0} *QOwnNotes.zip',
         $Checksum

--- a/build-systems/github/windows/build-zip.ps1
+++ b/build-systems/github/windows/build-zip.ps1
@@ -3,38 +3,49 @@
 ##################################################################################
 
 #dir -s ..\..\Qt
-echo "#define RELEASE ""GitHub Actions""" > release.h
+Write-Output "#define RELEASE ""GitHub Actions""" > release.h
 qmake QOwnNotes.pro -r
 lrelease QOwnNotes.pro
 make
-md ..\release
+# Create release directory
+New-Item -Path '..\release' -ItemType 'Directory'
 # copy the binary to our release path
-copy release\QOwnNotes.exe ..\release
+Copy-Item release\QOwnNotes.exe ..\release
 # copy Win64 OpenSSL v1.1.1g DLLs to the release path
-copy ..\build-systems\github\windows\libcrypto-1_1-x64.dll ..\release
-copy ..\build-systems\github\windows\libssl-1_1-x64.dll ..\release
+Copy-Item ..\build-systems\github\windows\libcrypto-1_1-x64.dll ..\release
+Copy-Item ..\build-systems\github\windows\libssl-1_1-x64.dll ..\release
 # copy unzip application for updater
-copy ..\appveyor\unzip.exe ..\release
+Copy-Item ..\appveyor\unzip.exe ..\release
 # copy updater script
-copy ..\appveyor\update.bat ..\release
+Copy-Item ..\appveyor\update.bat ..\release
 # copy portable mode launcher to the release path
-copy ..\appveyor\QOwnNotesPortable.bat ..\release
+Copy-Item ..\appveyor\QOwnNotesPortable.bat ..\release
 # copy translation files
-copy languages\*.qm ..\release
-cd ..\release
+Copy-Item languages\*.qm ..\release
+Set-Location ..\release
 # fetching dependencies of QT app
 # http://doc.qt.io/qt-5/windows-deployment.html
 # Bug in Qt 5.14+: https://stackoverflow.com/questions/61045959/windeployqt-error-unable-to-find-the-platform-plugin
 # Don't use "--release"! (maybe because of debug log?)
 windeployqt --debug QOwnNotes.exe
 # these dlls where missed by windeployqt
-copy ..\..\Qt\5.15.2\mingw81_64\bin\libwinpthread-1.dll .
-copy ..\..\Qt\5.15.2\mingw81_64\bin\libgcc_s_seh-1.dll .
+Copy-Item ..\..\Qt\5.15.2\mingw81_64\bin\libwinpthread-1.dll .
+Copy-Item ..\..\Qt\5.15.2\mingw81_64\bin\libgcc_s_seh-1.dll .
 # this dll didn't work when released by windeployqt
 # important: this dll needs to be updated when a new version of Qt is used!
 # search for it in the mingw* folder of your local installation of Qt
 # Update: we are trying a direct copy again
-copy ..\..\Qt\5.15.2\mingw81_64\bin\libstdc++-6.dll .
-# create zip archive
+Copy-Item ..\..\Qt\5.15.2\mingw81_64\bin\libstdc++-6.dll .
+# Create zip archive
 Compress-Archive -Path * -DestinationPath ..\QOwnNotes.zip
-$(CertUtil -hashfile ..\QOwnNotes.zip SHA256)[1] -replace " ","" | Out-File -FilePath ..\QOwnNotes.zip.sha256
+# Get sha256 checksum
+$Checksum = [string] (Get-FileHash -Path '..\QOwnNotes.zip' -Algorithm 'SHA256').'Hash'.ToLower().Trim()
+# Create sha256 file with checksum only
+Out-File -FilePath '..\QOwnNotes.zip.sha256' -Encoding 'utf8' -InputObject $Checksum
+# Create sha256 file with name of file
+Out-File -FilePath '..\QOwnNotes.zip.clickable.sha256' -Encoding 'utf8' -InputObject (
+    [string]::Format(
+        '{0} *QOwnNotes.zip',
+        $Checksum
+    )
+)

--- a/build-systems/github/windows/build-zip.ps1
+++ b/build-systems/github/windows/build-zip.ps1
@@ -39,7 +39,7 @@ Copy-Item ..\..\Qt\5.15.2\mingw81_64\bin\libstdc++-6.dll .
 # Create zip archive
 Compress-Archive -Path * -DestinationPath ..\QOwnNotes.zip
 # Get sha256 checksum
-$Checksum = [string] (Get-FileHash -Path '..\QOwnNotes.zip' -Algorithm 'SHA256').'Hash'.ToLower().Trim()
+$Checksum = [string] (Get-FileHash -Path '..\QOwnNotes.zip' -Algorithm 'SHA256').'Hash'.ToLower()
 # Create sha256 file with checksum only
 Out-File -FilePath '..\QOwnNotes.zip.sha256' -Encoding 'utf8' -InputObject $Checksum
 # Create sha256 file with name of file

--- a/build-systems/github/windows/build-zip.ps1
+++ b/build-systems/github/windows/build-zip.ps1
@@ -43,7 +43,7 @@ $Checksum = [string] (Get-FileHash -Path '..\QOwnNotes.zip' -Algorithm 'SHA256')
 # Create sha256 file with checksum only
 Out-File -FilePath '..\QOwnNotes.zip.sha256' -Encoding 'utf8' -InputObject $Checksum
 # Create sha256 file with name of file
-Out-File -FilePath '..\QOwnNotes.zip.clickable.sha256' -Encoding 'utf8' -InputObject (
+Out-File -FilePath '..\QOwnNotes.zip.sha256sum' -Encoding 'utf8' -InputObject (
     [string]::Format(
         '{0} *QOwnNotes.zip',
         $Checksum


### PR DESCRIPTION
Implements feature request #2938 without breaking existing .sha256 file included in releases.

Also:

* Changed PowerShell aliases into the actual commands they refer to.
* Make release directory with PowerShell `New-Item` instead of mkdir.