### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/webpage/src/ar/installation/macos.md
+++ b/webpage/src/ar/installation/macos.md
@@ -20,4 +20,4 @@ brew install qownnotes
 
 ## Nix
 
-كذلك يمكنك تثبيت QOwnNotes عبر [مدير الحزم Nix](https://nixos.wiki/wiki/Nix_package_manager) على ماك&nbsp;أو&nbsp;إس؛ انظر [التثبيت عبر Nix](./nix.md).
+كذلك يمكنك تثبيت QOwnNotes عبر [مدير الحزم Nix](https://wiki.nixos.org/wiki/Nix_package_manager) على ماك&nbsp;أو&nbsp;إس؛ انظر [التثبيت عبر Nix](./nix.md).

--- a/webpage/src/ar/installation/nix.md
+++ b/webpage/src/ar/installation/nix.md
@@ -1,6 +1,6 @@
 # التثبيت عبر Nix
 
-يمكنك تثبيت QOwnNotes عبر [مدير الحزم Nix](https://nixos.wiki/wiki/Nix_package_manager) على [NixOS](https://nixos.org/) وأنظمة أخرى؛ اسم الحزمة [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
+يمكنك تثبيت QOwnNotes عبر [مدير الحزم Nix](https://wiki.nixos.org/wiki/Nix_package_manager) على [NixOS](https://nixos.org/) وأنظمة أخرى؛ اسم الحزمة [qownnotes](https://search.nixos.org/packages?channel=unstable&show=qownnotes).
 
 انظر [QOwnNotes على nix](https://search.nixos.org/packages?channel=unstable&show=qownnotes) للمزيد من المعلومات.
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️