### PR TITLE
Dont deploy debug dlls

### DIFF
--- a/build-systems/github/windows/build-zip-qt6.ps1
+++ b/build-systems/github/windows/build-zip-qt6.ps1
@@ -8,8 +8,9 @@ $ErrorActionPreference = "Stop"
 #dir -s ..\..\Qt
 Write-Host $Env:QT_VERSION
 Write-Output "#define RELEASE ""GitHub Actions""" > release.h
-qmake6 QOwnNotes.pro -r
+qmake6 CONFIG+=release QOwnNotes.pro -r
 lrelease QOwnNotes.pro
+set CL=/MP
 nmake
 # Create release directory
 New-Item -Path '..\release' -ItemType 'Directory'
@@ -30,8 +31,7 @@ Set-Location ..\release
 # fetching dependencies of QT app
 # http://doc.qt.io/qt-5/windows-deployment.html
 # Bug in Qt 5.14+: https://stackoverflow.com/questions/61045959/windeployqt-error-unable-to-find-the-platform-plugin
-# Don't use "--release"! (maybe because of debug log?)
-windeployqt --debug QOwnNotes.exe
+windeployqt -core -gui -widgets -sql -svg -network -xml -printsupport -qml -websockets -concurrent QOwnNotes.exe
 
 # Create zip archive
 Get-ChildItem

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2.2)
+cmake_minimum_required(VERSION 3.5)
 project(QOwnNotes)
 
 # BEGIN options
@@ -12,6 +12,12 @@ else()
     set(QT_VERSION_MAJOR 5)
 endif()
 
+# put the QOwnNotes.exe in build directory
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+# for intellisence
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
 # include some Botan settings
 add_subdirectory(libraries/botan)
 #include sonnet core directory, required for building plugins
@@ -19,6 +25,8 @@ include_directories(libraries/sonnet/src/core)
 #some hunspell settings for windows
 include(libraries/sonnet/src/plugins/hunspell/hunspell/CMakeLists.txt)
 
+# noneed for md2html
+set(BUILD_MD2HTML_EXECUTABLE FALSE)
 add_subdirectory(libraries/md4c)
 
 add_executable(QOwnNotes "")
@@ -100,11 +108,6 @@ find_package(Qt${QT_VERSION_MAJOR} COMPONENTS REQUIRED
     Qml
     Concurrent
 )
-
-# if(UNIX)
-#     find_package(Qt5 COMPONENTS REQUIRED X11Extras)
-#     find_package( X11 REQUIRED )
-# endif()
 
 find_program(CCACHE_FOUND ccache)
 
@@ -596,12 +599,6 @@ target_link_libraries(QOwnNotes PRIVATE
     Google::DiffMatchPatch
     md4c-html
 )
-# if(UNIX)
-#     target_link_libraries(QOwnNotes PRIVATE
-#         Qt5::X11Extras
-#         ${X11_LIBRARIES}
-#     )
-# endif()
 
 if (USE_QLITEHTML)
     target_link_libraries(QOwnNotes PRIVATE

--- a/src/libraries/botan/CMakeLists.txt
+++ b/src/libraries/botan/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2.2)
+cmake_minimum_required(VERSION 3.5)
 project(Botan)
 
 option(BUILD_WITH_SYSTEM_BOTAN "Build using system installed Botan 2 crypto library" OFF)

--- a/src/libraries/diff_match_patch/CMakeLists.txt
+++ b/src/libraries/diff_match_patch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(DiffMatchPatchLib)
 
 add_library(diff_match_patch STATIC

--- a/src/libraries/fakevim/CMakeLists.txt
+++ b/src/libraries/fakevim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(fakevim VERSION 0.0.1)
 
 # Library name


### PR DESCRIPTION
- Use release dlls for windows
- Raise min cmake version to 3.5 to silence warnings
- Change QOwnNotes.exe directory to `build` in cmake so that its the same as qmake