### PR TITLE
Add note conversion tool "jimmy" to docs

### DIFF
--- a/webpage/src/getting-started/importing-notes.md
+++ b/webpage/src/getting-started/importing-notes.md
@@ -10,6 +10,12 @@ Images, attachments, tags, basic formatting and metadata will be imported as wel
 
 There is a Joplin import dialog you can reach in the `Note / Import` menu.
 
+## Various Formats
+
+The command line tool "jimmy" can convert various formats to Markdown (such as [Google Keep](https://marph91.github.io/jimmy/formats/google_keep/), [Synology Note Station](https://marph91.github.io/jimmy/formats/synology_note_station/) and [more](https://marph91.github.io/jimmy/)). To preserve as much metadata as possible, it's recommended to apply [additional tweaks](https://marph91.github.io/jimmy/import_instructions/#qownnotes).
+
+If there are any issues with the conversion, feel free to open a ticket at [Github](https://github.com/marph91/jimmy).
+
 ## Google Keep
 
 > Download Keep tasks using Google Takeout

--- a/webpage/src/getting-started/importing-notes.md
+++ b/webpage/src/getting-started/importing-notes.md
@@ -28,7 +28,7 @@ If there are any issues with the conversion, feel free to open a ticket at [Gith
 > 
 > Replace Keep by the folder containing notes in JSON format. The out folder will be created if it doesn't exist.
 
-From https://gitlab.com/-/snippets/2002921
+From <https://gitlab.com/-/snippets/2002921>
 
 ## Tomboy
 


### PR DESCRIPTION
This PR mentions "jimmy" at the "Importing notes" page. I placed it behind the built-in imports.

If I understood correctly, translations to other languages will be done through Crowdin.

Resolves: https://github.com/pbek/QOwnNotes/issues/3133