### PR TITLE
refactor: replace non-empty QString constructors with QStringLiteral()

### DIFF
--- a/src/dialogs/nextclouddeckdialog.cpp
+++ b/src/dialogs/nextclouddeckdialog.cpp
@@ -33,7 +33,7 @@ void NextcloudDeckDialog::on_saveButton_clicked() {
 
     if (cardId > 0) {
         auto linkText =
-            QString("[%1](%2)").arg(title, nextcloudDeckService.getCardLinkForId(cardId));
+            QStringLiteral("[%1](%2)").arg(title, nextcloudDeckService.getCardLinkForId(cardId));
 
 #ifndef INTEGRATION_TESTS
         MainWindow *mainWindow = MainWindow::instance();

--- a/src/dialogs/settingsdialog.cpp
+++ b/src/dialogs/settingsdialog.cpp
@@ -4245,7 +4245,7 @@ void SettingsDialog::on_loginFlowButton_clicked() {
 
         QPointer<SettingsDialog> alive(this);
 
-        auto postData = QString("token=" + token).toLocal8Bit();
+        auto postData = QStringLiteral("token=%1").arg(token).toLocal8Bit();
         auto data = Utils::Misc::downloadUrl(pollUrl, true, postData);
 
         if (!alive) {

--- a/src/dialogs/tododialog.cpp
+++ b/src/dialogs/tododialog.cpp
@@ -949,7 +949,7 @@ void TodoDialog::reloadCurrentTags() {
 QString TodoDialog::getTagString() {
     // Remove any possible empty items
     _todoTagsList.removeAll(QString(""));
-    _todoTagsList.removeAll(QString(" "));
+    _todoTagsList.removeAll(QStringLiteral(" "));
     QString fullTagString;
     // We can't use regular join since it also joins escaped commas
     for (const auto &str : _todoTagsList) {

--- a/src/dialogs/welcomedialog.cpp
+++ b/src/dialogs/welcomedialog.cpp
@@ -94,7 +94,7 @@ bool WelcomeDialog::handleNoteFolderSetup() {
         Utils::Misc::printInfo(QStringLiteral("Note path '%1' exists.").arg(_notesPath));
     } else {
         if (ui->createNoteFolderCheckBox->isChecked()) {
-            Utils::Misc::printInfo(QString("Note path '%1' doesn't exist yet and will "
+            Utils::Misc::printInfo(QStringLiteral("Note path '%1' doesn't exist yet and will "
                                            "be created.")
                                        .arg(_notesPath));
 

--- a/src/entities/notefolder.cpp
+++ b/src/entities/notefolder.cpp
@@ -530,12 +530,12 @@ bool NoteFolder::isPathNoteFolder(const QString &path) {
 
 void NoteFolder::setSettingsValue(const QString &key, const QVariant &value) {
     SettingsService settings;
-    settings.setValue(QString("NoteFolder-%1/%2").arg(QString::number(id), key), value);
+    settings.setValue(QStringLiteral("NoteFolder-%1/%2").arg(id).arg(key), value);
 }
 
 QVariant NoteFolder::settingsValue(const QString &key, const QVariant &defaultValue) const {
     const SettingsService settings;
-    return settings.value(QString("NoteFolder-%1/%2").arg(QString::number(id), key), defaultValue);
+    return settings.value(QStringLiteral("NoteFolder-%1/%2").arg(id).arg(key), defaultValue);
 }
 
 QDebug operator<<(QDebug dbg, const NoteFolder &noteFolder) {

--- a/src/libraries/diff_match_patch/diff_match_patch.cpp
+++ b/src/libraries/diff_match_patch/diff_match_patch.cpp
@@ -74,8 +74,8 @@ QString Diff::toString() const {
   QString prettyText = text;
   // Replace linebreaks with Pilcrow signs.
   prettyText.replace('\n', u'\u00b6');
-  return QString("Diff(") + strOperation(operation) + QString(",\"")
-      + prettyText + QString("\")");
+  return QStringLiteral("Diff(") + strOperation(operation) + QStringLiteral(",\"")
+      + prettyText + QStringLiteral("\")");
 }
 
 /**
@@ -125,24 +125,24 @@ bool Patch::isNull() const {
 QString Patch::toString() {
   QString coords1, coords2;
   if (length1 == 0) {
-    coords1 = QString::number(start1) + QString(",0");
+    coords1 = QString::number(start1) + QStringLiteral(",0");
   } else if (length1 == 1) {
     coords1 = QString::number(start1 + 1);
   } else {
-    coords1 = QString::number(start1 + 1) + QString(",")
+    coords1 = QString::number(start1 + 1) + QStringLiteral(",")
         + QString::number(length1);
   }
   if (length2 == 0) {
-    coords2 = QString::number(start2) + QString(",0");
+    coords2 = QString::number(start2) + QStringLiteral(",0");
   } else if (length2 == 1) {
     coords2 = QString::number(start2 + 1);
   } else {
-    coords2 = QString::number(start2 + 1) + QString(",")
+    coords2 = QString::number(start2 + 1) + QStringLiteral(",")
         + QString::number(length2);
   }
   QString text;
-  text = QString("@@ -") + coords1 + QString(" +") + coords2
-      + QString(" @@\n");
+  text = QStringLiteral("@@ -") + coords1 + QStringLiteral(" +") + coords2
+      + QStringLiteral(" @@\n");
   // Escape the body of the patch with %xx notation.
   foreach (Diff aDiff, diffs) {
     switch (aDiff.operation) {
@@ -157,7 +157,7 @@ QString Patch::toString() {
         break;
     }
     text += QString(QUrl::toPercentEncoding(aDiff.text, " !~*'();/?:@&=+$,#"))
-        + QString("\n");
+        + QStringLiteral("\n");
   }
 
   return text;
@@ -1287,15 +1287,15 @@ QString diff_match_patch::diff_prettyHtml(const QList<Diff> &diffs) {
         .replace(">", "&gt;").replace("\n", "&para;<br>");
     switch (aDiff.operation) {
       case INSERT:
-        html += QString("<ins style=\"background:#e6ffe6;\">") + text
-            + QString("</ins>");
+        html += QStringLiteral("<ins style=\"background:#e6ffe6;\">") + text
+            + QStringLiteral("</ins>");
         break;
       case DELETE:
-        html += QString("<del style=\"background:#ffe6e6;\">") + text
-            + QString("</del>");
+        html += QStringLiteral("<del style=\"background:#ffe6e6;\">") + text
+            + QStringLiteral("</del>");
         break;
       case EQUAL:
-        html += QString("<span>") + text + QString("</span>");
+        html += QStringLiteral("<span>") + text + QStringLiteral("</span>");
         break;
     }
   }
@@ -1357,16 +1357,16 @@ QString diff_match_patch::diff_toDelta(const QList<Diff> &diffs) {
       case INSERT: {
         QString encoded = QString(QUrl::toPercentEncoding(aDiff.text,
             " !~*'();/?:@&=+$,#"));
-        text += QString("+") + encoded + QString("\t");
+        text += QStringLiteral("+") + encoded + QStringLiteral("\t");
         break;
       }
       case DELETE:
-        text += QString("-") + QString::number(aDiff.text.length())
-            + QString("\t");
+        text += QStringLiteral("-") + QString::number(aDiff.text.length())
+            + QStringLiteral("\t");
         break;
       case EQUAL:
-        text += QString("=") + QString::number(aDiff.text.length())
-            + QString("\t");
+        text += QStringLiteral("=") + QString::number(aDiff.text.length())
+            + QStringLiteral("\t");
         break;
     }
   }
@@ -1402,7 +1402,7 @@ QList<Diff> diff_match_patch::diff_fromDelta(const QString &text1,
         int n;
         n = param.toInt();
         if (n < 0) {
-          throw QString("Negative number in diff_fromDelta: %1").arg(param);
+          throw QStringLiteral("Negative number in diff_fromDelta: %1").arg(param);
         }
         QString text;
         text = safeMid(text1, pointer, n);
@@ -1415,12 +1415,12 @@ QList<Diff> diff_match_patch::diff_fromDelta(const QString &text1,
         break;
       }
       default:
-        throw QString("Invalid diff operation in diff_fromDelta: %1")
+        throw QStringLiteral("Invalid diff operation in diff_fromDelta: %1")
             .arg(token[0]);
     }
   }
   if (pointer != text1.length()) {
-    throw QString("Delta length (%1) smaller than source text length (%2)")
+    throw QStringLiteral("Delta length (%1) smaller than source text length (%2)")
         .arg(pointer).arg(text1.length());
   }
   return diffs;
@@ -2058,7 +2058,7 @@ QList<Patch> diff_match_patch::patch_fromText(const QString &textline) {
   while (!text.isEmpty()) {
     auto patchHeader = patchHeaderRe.match(text.front());
     if (!patchHeader.hasMatch()) {
-      throw QString("Invalid patch string: %1").arg(text.front());
+      throw QStringLiteral("Invalid patch string: %1").arg(text.front());
     }
 
     patch = Patch();
@@ -2108,7 +2108,7 @@ QList<Patch> diff_match_patch::patch_fromText(const QString &textline) {
         break;
       } else {
         // WTF?
-        throw QString("Invalid patch mode '%1' in: %2").arg(sign).arg(line);
+        throw QStringLiteral("Invalid patch mode '%1' in: %2").arg(sign).arg(line);
         return QList<Patch>();
       }
       text.removeFirst();

--- a/src/libraries/diff_match_patch/diff_match_patch.h
+++ b/src/libraries/diff_match_patch/diff_match_patch.h
@@ -47,8 +47,8 @@
  #include "diff_match_patch.h"
  int main(int argc, char **argv) {
    diff_match_patch dmp;
-   QString str1 = QString("First string in diff");
-   QString str2 = QString("Second string in diff");
+   QString str1 = QStringLiteral("First string in diff");
+   QString str2 = QStringLiteral("Second string in diff");
 
    QString strPatch = dmp.patch_toText(dmp.patch_make(str1, str2));
    QPair<QString, QVector<bool> > out

--- a/src/libraries/fakevim/fakevim/fakevimhandler.cpp
+++ b/src/libraries/fakevim/fakevim/fakevimhandler.cpp
@@ -488,7 +488,7 @@ static QString vimPatternToQtPattern_QString(const QString &needle, bool &initIg
             } else {
                 pattern.append(c);
             }
-        } else if (QString("(){}+|?").indexOf(c) != -1) {
+        } else if (QStringLiteral("(){}+|?").indexOf(c) != -1) {
             if (c == '{') {
                 curly = escape;
             } else if (c == '}' && curly) {
@@ -761,9 +761,9 @@ static void bracketSearchForward(QTextCursor *tc, const QString &needleExp, int 
                                  bool searchWithCommand)
 {
 #if QT_VERSION < QT_VERSION_CHECK(5,5,0)
-    QRegExp re(searchWithCommand ? QString("^\\}|^\\{") : needleExp);
+    QRegExp re(searchWithCommand ? QStringLiteral("^\\}|^\\{") : needleExp);
 #else
-    QRegularExpression re(searchWithCommand ? QString("^\\}|^\\{") : needleExp);
+    QRegularExpression re(searchWithCommand ? QStringLiteral("^\\}|^\\{") : needleExp);
 #endif
 
     QTextCursor tc2 = *tc;
@@ -1107,7 +1107,7 @@ Range::Range(int b, int e, RangeMode m)
 
 QString Range::toString() const
 {
-    return QString("%1-%2 (mode: %3)").arg(beginPos).arg(endPos).arg(rangemode);
+    return QStringLiteral("%1-%2 (mode: %3)").arg(beginPos).arg(endPos).arg(rangemode);
 }
 
 bool Range::isValid() const
@@ -1153,7 +1153,7 @@ QString quoteUnprintable(const QString &ba)
         else if (cc == '\n')
             res += "<CR>";
         else
-            res += QString("\\x%1").arg(c.unicode(), 2, 16, QLatin1Char('0'));
+            res += QStringLiteral("\\x%1").arg(c.unicode(), 2, 16, QLatin1Char('0'));
     }
     return res;
 }
@@ -2864,9 +2864,9 @@ void FakeVimHandler::Private::commitInsertState()
         --insertState.backspaces;
 
     // backspaces in front of inserted text
-    lastInsertion.prepend(QString("<BS>").repeated(insertState.backspaces));
+    lastInsertion.prepend(QStringLiteral("<BS>").repeated(insertState.backspaces));
     // deletes after inserted text
-    lastInsertion.prepend(QString("<DELETE>").repeated(insertState.deletes));
+    lastInsertion.prepend(QStringLiteral("<DELETE>").repeated(insertState.deletes));
 
     // Remove indentation.
     lastInsertion.replace(QRegularExpression("(^|\n)[\\t ]+"), "\\1");
@@ -3728,7 +3728,7 @@ void FakeVimHandler::Private::finishMovement(const QString &dotCommandMovement)
         int beginLine = lineForPosition(anchor());
         int endLine = lineForPosition(position());
         setPosition(qMin<int>(anchor(), position()));
-        enterExMode(QString(".,+%1!").arg(qAbs(endLine - beginLine)));
+        enterExMode(QStringLiteral(".,+%1!").arg(qAbs(endLine - beginLine)));
         return;
     }
 
@@ -3846,7 +3846,7 @@ void FakeVimHandler::Private::finishMovement(const QString &dotCommandMovement)
         QString dotCommand = dotCommandFromSubMode(g.submode);
         if (!dotCommand.isEmpty()) {
             if (g.submode == ReplaceWithRegisterSubMode)
-                dotCommand = QString("\"%1%2").arg(QChar(m_register)).arg(dotCommand);
+                dotCommand = QStringLiteral("\"%1%2").arg(QChar(m_register)).arg(dotCommand);
 
             setDotCommand(dotCommand + dotCommandMovement);
         }
@@ -3994,7 +3994,7 @@ void FakeVimHandler::Private::updateMiniBuffer()
     int linesInDoc = linesInDocument();
     int l = cursorLine();
     QString status;
-    const QString pos = QString("%1,%2")
+    const QString pos = QStringLiteral("%1,%2")
         .arg(l + 1).arg(physicalCursorColumn() + 1);
     // FIXME: physical "-" logical
     if (linesInDoc != 0)
@@ -4037,7 +4037,7 @@ bool FakeVimHandler::Private::handleCommandSubSubMode(const Input &input)
         handled = handleFfTt(g.semicolonKey);
         g.subsubmode = NoSubSubMode;
         if (handled) {
-            finishMovement(QString("%1%2%3")
+            finishMovement(QStringLiteral("%1%2%3")
                            .arg(count())
                            .arg(g.semicolonType.text())
                            .arg(g.semicolonKey));
@@ -4072,7 +4072,7 @@ bool FakeVimHandler::Private::handleCommandSubSubMode(const Input &input)
             handled = false;
         g.subsubmode = NoSubSubMode;
         if (handled) {
-            finishMovement(QString("%1%2%3")
+            finishMovement(QStringLiteral("%1%2%3")
                            .arg(count())
                            .arg(g.subsubdata.text())
                            .arg(input.text()));
@@ -4093,7 +4093,7 @@ bool FakeVimHandler::Private::handleCommandSubSubMode(const Input &input)
             q->foldGoTo(input.is('j') ? count() : -count(), false);
             if (pos != position()) {
                 handled = true;
-                finishMovement(QString("%1z%2")
+                finishMovement(QStringLiteral("%1z%2")
                                .arg(count())
                                .arg(input.text()));
             }
@@ -4122,7 +4122,7 @@ bool FakeVimHandler::Private::handleCommandSubSubMode(const Input &input)
         if (handled) {
             if (lineForPosition(pos) != lineForPosition(position()))
                 recordJump(pos);
-            finishMovement(QString("%1%2%3")
+            finishMovement(QStringLiteral("%1%2%3")
                            .arg(count())
                            .arg(g.subsubmode == OpenSquareSubSubMode ? '[' : ']')
                            .arg(input.text()));
@@ -4335,7 +4335,7 @@ bool FakeVimHandler::Private::handleMovement(const Input &input)
         g.gflag = true;
         return true;
     } else if (input.is('g') || input.is('G')) {
-        QString dotCommand = QString("%1G").arg(count);
+        QString dotCommand = QStringLiteral("%1G").arg(count);
         recordJump();
         if (input.is('G') && g.mvcount == 0)
             dotCommand = "G";
@@ -4597,7 +4597,7 @@ bool FakeVimHandler::Private::handleNoSubMode(const Input &input)
     } else if (input.is('!') && isNoVisualMode()) {
         g.submode = FilterSubMode;
     } else if (input.is('!') && isVisualMode()) {
-        enterExMode(QString("!"));
+        enterExMode(QStringLiteral("!"));
     } else if (input.is('"')) {
         g.submode = RegisterSubMode;
     } else if (input.is(',')) {
@@ -4658,7 +4658,7 @@ bool FakeVimHandler::Private::handleNoSubMode(const Input &input)
             if (count == 0) {
                 dotCommand = "gcc";
             } else {
-                dotCommand = QString("gc%1j").arg(count);
+                dotCommand = QStringLiteral("gc%1j").arg(count);
             }
 
             leaveVisualMode();
@@ -4804,7 +4804,7 @@ bool FakeVimHandler::Private::handleNoSubMode(const Input &input)
     } else if (input.isControl('o')) {
         jump(-count());
     } else if (input.is('p') || input.is('P') || input.isShift(Qt::Key_Insert)) {
-        dotCommand = QString("\"%1%2%3").arg(QChar(m_register)).arg(count()).arg(input.asChar());
+        dotCommand = QStringLiteral("\"%1%2%3").arg(QChar(m_register)).arg(count()).arg(input.asChar());
 
         pasteText(!input.is('P'));
         setTargetColumn();
@@ -4920,7 +4920,7 @@ bool FakeVimHandler::Private::handleNoSubMode(const Input &input)
                 moveLeft();
             setAnchor();
         } else {
-            const QString movementCommand = QString("%1l%1l").arg(count());
+            const QString movementCommand = QStringLiteral("%1l%1l").arg(count());
             handleAs("g" + input.toString() + movementCommand);
         }
     } else if (input.is('@')) {
@@ -4972,7 +4972,7 @@ void FakeVimHandler::Private::handleChangeDeleteYankSubModes()
     setAnchorAndPosition(anc, pos);
 
     if (!dotCommand.isEmpty())
-        setDotCommand(QString("%2%1%1").arg(dotCommand), count());
+        setDotCommand(QStringLiteral("%2%1%1").arg(dotCommand), count());
 
     finishMovement();
 
@@ -5003,7 +5003,7 @@ bool FakeVimHandler::Private::handleReplaceSubMode(const Input &input)
         if (input.isReturn()) {
             beginEditBlock();
             replaceText(range, QString());
-            insertText(QString("\n"));
+            insertText(QStringLiteral("\n"));
             endEditBlock();
         } else {
             replaceText(range, QString(count(), c));
@@ -5032,7 +5032,7 @@ bool FakeVimHandler::Private::handleCommentSubMode(const Input &input)
     const int pos = lastPositionInLine(cursorLine() + 1);
     setAnchorAndPosition(anc, pos);
 
-    setDotCommand(QString("%1gcc").arg(count()));
+    setDotCommand(QStringLiteral("%1gcc").arg(count()));
 
     finishMovement();
 
@@ -5157,7 +5157,7 @@ bool FakeVimHandler::Private::handleRegisterSubMode(const Input &input)
     bool handled = false;
 
     QChar reg = input.asChar();
-    if (QString("*+.%#:-\"_").contains(reg) || reg.isLetterOrNumber()) {
+    if (QStringLiteral("*+.%#:-\"_").contains(reg) || reg.isLetterOrNumber()) {
         m_register = reg.unicode();
         handled = true;
     }
@@ -5174,7 +5174,7 @@ bool FakeVimHandler::Private::handleShiftSubMode(const Input &input)
     g.movetype = MoveLineWise;
     pushUndoState();
     moveDown(count() - 1);
-    setDotCommand(QString("%2%1%1").arg(input.asChar()), count());
+    setDotCommand(QStringLiteral("%2%1%1").arg(input.asChar()), count());
     finishMovement();
     g.submode = NoSubMode;
 
@@ -5194,7 +5194,7 @@ bool FakeVimHandler::Private::handleChangeCaseSubMode(const Input &input)
     pushUndoState();
     setAnchor();
     setPosition(lastPositionInLine(cursorLine() + count()) + 1);
-    finishMovement(QString("%1%2").arg(count()).arg(input.raw()));
+    finishMovement(QStringLiteral("%1%2").arg(count()).arg(input.raw()));
     g.submode = NoSubMode;
 
     return true;
@@ -5403,7 +5403,7 @@ void FakeVimHandler::Private::finishInsertMode()
                     int spaces = pos.column - m_cursor.positionInBlock();
                     if (spaces > 0) {
                         setAnchor();
-                        m_cursor.insertText(QString(" ").repeated(spaces));
+                        m_cursor.insertText(QStringLiteral(" ").repeated(spaces));
                     }
                 } else if (m_cursor.positionInBlock() != pos.column) {
                     continue;
@@ -5693,7 +5693,7 @@ void FakeVimHandler::Private::stopRecording()
 
 void FakeVimHandler::Private::handleAs(const QString &command)
 {
-    QString cmd = QString("\"%1").arg(QChar(m_register));
+    QString cmd = QStringLiteral("\"%1").arg(QChar(m_register));
 
     if (command.contains("%1"))
         cmd.append(command.arg(count()));
@@ -5713,7 +5713,7 @@ bool FakeVimHandler::Private::executeRegister(int reg)
     // TODO: Prompt for an expression to execute if register is '='.
     if (reg == '@' && g.lastExecutedRegister != 0)
         reg = g.lastExecutedRegister;
-    else if (QString("\".*+").contains(regChar) || regChar.isLetterOrNumber())
+    else if (QStringLiteral("\".*+").contains(regChar) || regChar.isLetterOrNumber())
         g.lastExecutedRegister = reg;
     else
         return false;
@@ -5855,7 +5855,7 @@ int FakeVimHandler::Private::parseLineAddress(QString *cmd)
     } else if (c == '-' || c == '+') { // add or subtract from current line number
         result = cursorBlockNumber();
     } else if (c == '/' || c == '?'
-        || (c == '\\' && cmd->size() > 1 && QString("/?&").contains(cmd->at(1)))) {
+        || (c == '\\' && cmd->size() > 1 && QStringLiteral("/?&").contains(cmd->at(1)))) {
         // search for expression
         SearchData sd;
         if (c == '/' || c == '?') {
@@ -6024,7 +6024,7 @@ bool FakeVimHandler::Private::handleExSubstituteCommand(const ExCommand &cmd)
 {
     // :substitute
     if (!cmd.matches("s", "substitute")
-        && !(cmd.cmd.isEmpty() && !cmd.args.isEmpty() && QString("&~").contains(cmd.args[0]))) {
+        && !(cmd.cmd.isEmpty() && !cmd.args.isEmpty() && QStringLiteral("&~").contains(cmd.args[0]))) {
         return false;
     }
 
@@ -6232,7 +6232,7 @@ bool FakeVimHandler::Private::handleExHistoryCommand(const ExCommand &cmd)
         int i = 0;
         foreach (const QString &item, g.commandBuffer.historyItems()) {
             ++i;
-            info += QString("%1 %2\n").arg(i, -8).arg(item);
+            info += QStringLiteral("%1 %2\n").arg(i, -8).arg(item);
         }
         q->extraInformationChanged(info);
     } else {
@@ -6261,7 +6261,7 @@ bool FakeVimHandler::Private::handleExRegisterCommand(const ExCommand &cmd)
     const auto& registers = regs;
     for (char reg : registers) {
         QString value = quoteUnprintable(registerContents(reg));
-        info += QString("\"%1   %2\n").arg(reg).arg(value);
+        info += QStringLiteral("\"%1   %2\n").arg(reg).arg(value);
     }
     q->extraInformationChanged(info);
 
@@ -6415,7 +6415,7 @@ bool FakeVimHandler::Private::handleExMoveCommand(const ExCommand &cmd)
     if (insertAtEnd) {
         moveBehindEndOfLine();
         text.chop(1);
-        insertText(QString("\n"));
+        insertText(QStringLiteral("\n"));
     }
     insertText(text);
 
@@ -6514,7 +6514,7 @@ bool FakeVimHandler::Private::handleExWriteCommand(const ExCommand &cmd)
         file3.open(QIODevice::ReadOnly);
         QByteArray ba = file3.readAll();
         showMessage(MessageInfo, Tr::tr("\"%1\" %2 %3L, %4C written.")
-            .arg(fileName).arg(exists ? QString(" ") : Tr::tr(" [New] "))
+            .arg(fileName).arg(exists ? QStringLiteral(" ") : Tr::tr(" [New] "))
             .arg(ba.count('\n')).arg(ba.size()));
         //if (quitAll)
         //    passUnknownExCommand(forced ? "qa!" : "qa");
@@ -6656,7 +6656,7 @@ bool FakeVimHandler::Private::handleExSortCommand(const ExCommand &cmd)
 bool FakeVimHandler::Private::handleExNohlsearchCommand(const ExCommand &cmd)
 {
     // :noh, :nohl, ..., :nohlsearch
-    if (cmd.cmd.size() < 3 || !QString("nohlsearch").startsWith(cmd.cmd))
+    if (cmd.cmd.size() < 3 || !QStringLiteral("nohlsearch").startsWith(cmd.cmd))
         return false;
 
     g.highlightsCleared = true;
@@ -8066,7 +8066,7 @@ void FakeVimHandler::Private::insertNewLine()
             return;
     }
 
-    insertText(QString("\n"));
+    insertText(QStringLiteral("\n"));
     insertAutomaticIndentation(true);
 }
 
@@ -8720,7 +8720,7 @@ void FakeVimHandler::Private::enterExMode(const QString &contents)
     g.currentMessage.clear();
     g.commandBuffer.clear();
     if (isVisualMode())
-        g.commandBuffer.setContents(QString("'<,'>") + contents, contents.size() + 5);
+        g.commandBuffer.setContents(QStringLiteral("'<,'>") + contents, contents.size() + 5);
     else
         g.commandBuffer.setContents(contents, contents.size());
     g.mode = ExMode;
@@ -8848,7 +8848,7 @@ QString FakeVimHandler::Private::visualDotCommand() const
 
     const int down = qAbs(start.blockNumber() - end.blockNumber());
     if (down != 0)
-        command.append(QString("%1j").arg(down));
+        command.append(QStringLiteral("%1j").arg(down));
 
     const int right = start.positionInBlock() - end.positionInBlock();
     if (right != 0) {
@@ -9134,7 +9134,7 @@ bool FakeVimHandler::Private::changeNumberTextObject(int count)
 
     // preserve leading zeroes
     if ((octal || hex) && repl.size() < num.size())
-        prefix.append(QString("0").repeated(num.size() - repl.size()));
+        prefix.append(QStringLiteral("0").repeated(num.size() - repl.size()));
     repl.prepend(prefix);
 
     pos += block.position();

--- a/src/libraries/qlitehtml/src/container_qpainter.cpp
+++ b/src/libraries/qlitehtml/src/container_qpainter.cpp
@@ -381,7 +381,7 @@ static QCursor toQCursor(const QString &c)
         return {Qt::BusyCursor};
     if (c == "zoom-in")
         return {Qt::ArrowCursor}; // ???
-    qWarning(log) << QString("unknown cursor property \"%1\"").arg(c).toUtf8().constData();
+    qWarning(log) << QStringLiteral("unknown cursor property \"%1\"").arg(c).toUtf8().constData();
     return {Qt::ArrowCursor};
 }
 
@@ -630,8 +630,8 @@ void DocumentContainerPrivate::load_image(const litehtml::tchar_t *src,
     const auto qtSrc = QString::fromUtf8(src);
     const auto qtBaseUrl = QString::fromUtf8(baseurl);
     Q_UNUSED(redraw_on_ready)
-    qDebug() << "load_image:" << QString("src = \"%1\";").arg(qtSrc).toUtf8().constData()
-                << QString("base = \"%1\"").arg(qtBaseUrl).toUtf8().constData();
+    qDebug() << "load_image:" << QStringLiteral("src = \"%1\";").arg(qtSrc).toUtf8().constData()
+                << QStringLiteral("base = \"%1\"").arg(qtBaseUrl).toUtf8().constData();
     const QUrl url = resolveUrl(qtSrc, qtBaseUrl);
     if (m_pixmaps.contains(url))
         return;
@@ -650,8 +650,8 @@ void DocumentContainerPrivate::get_image_size(const litehtml::tchar_t *src,
     const auto qtBaseUrl = QString::fromUtf8(baseurl);
     if (qtSrc.isEmpty()) // for some reason that happens
         return;
-    qDebug(log) << "get_image_size:" << QString("src = \"%1\";").arg(qtSrc).toUtf8().constData()
-                << QString("base = \"%1\"").arg(qtBaseUrl).toUtf8().constData();
+    qDebug(log) << "get_image_size:" << QStringLiteral("src = \"%1\";").arg(qtSrc).toUtf8().constData()
+                << QStringLiteral("base = \"%1\"").arg(qtBaseUrl).toUtf8().constData();
     const QPixmap pm = getPixmap(qtSrc, qtBaseUrl);
     sz.width = pm.width();
     sz.height = pm.height();
@@ -1057,9 +1057,9 @@ int DocumentContainer::documentHeight() const
 int DocumentContainer::anchorY(const QString &anchorName) const
 {
     litehtml::element::ptr element = d->m_document->root()->select_one(
-        QString("#%1").arg(anchorName).toStdString());
+        QStringLiteral("#%1").arg(anchorName).toStdString());
     if (!element) {
-        element = d->m_document->root()->select_one(QString("[name=%1]").arg(anchorName).toStdString());
+        element = d->m_document->root()->select_one(QStringLiteral("[name=%1]").arg(anchorName).toStdString());
     }
     if (element)
         return element->get_placement().y;
@@ -1272,7 +1272,7 @@ void DocumentContainer::findText(const QString &text,
 
     QString term = QRegularExpression::escape(text);
     if (flags & QTextDocument::FindWholeWords)
-        term = QString("\\b%1\\b").arg(term);
+        term = QStringLiteral("\\b%1\\b").arg(term);
     const QRegularExpression::PatternOptions patternOptions
         = (flags & QTextDocument::FindCaseSensitively) ? QRegularExpression::NoPatternOption
                                                        : QRegularExpression::CaseInsensitiveOption;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -608,7 +608,7 @@ int main(int argc, char *argv[]) {
 
             // send message if an action was set
             if (!action.isEmpty()) {
-                app.sendMessage(QString("startupAction:" + action).toUtf8());
+                app.sendMessage(QStringLiteral("startupAction:%1").arg(action).toUtf8());
             }
 
             app.exit(0);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3827,7 +3827,7 @@ void MainWindow::setCurrentNote(Note note, bool updateNoteText, bool updateSelec
     // update file path label
     _noteFilePathLabel->updateText();
 
-    //    putenv(QString("QOWNNOTES_CURRENT_NOTE_PATH=" + currentNote
+    //    putenv(QStringLiteral("QOWNNOTES_CURRENT_NOTE_PATH=%1").arg(currentNote)
     //            .fullNoteFilePath()).toLatin1().data());
     //    setenv("QOWNNOTES_CURRENT_NOTE_PATH",
     //           currentNote.fullNoteFilePath().toLatin1().data(),

--- a/src/services/scriptingservice.cpp
+++ b/src/services/scriptingservice.cpp
@@ -2406,7 +2406,7 @@ void ScriptingService::onScriptThreadDone(ScriptThread *thread) {
  */
 QString ScriptingService::cacheDir(const QString &subDir) const {
     QString cacheDir =
-        QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + QString("/scripts/");
+        QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + QStringLiteral("/scripts/");
 
     if (!subDir.isEmpty()) {
         cacheDir = QDir::toNativeSeparators(cacheDir + subDir);
@@ -2428,7 +2428,7 @@ QString ScriptingService::cacheDir(const QString &subDir) const {
  */
 bool ScriptingService::clearCacheDir(const QString &subDir) const {
     QString cacheDir =
-        QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + QString("/scripts/");
+        QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + QStringLiteral("/scripts/");
 
     if (!subDir.isEmpty()) {
         cacheDir = QDir::toNativeSeparators(cacheDir + subDir);

--- a/src/utils/cli.cpp
+++ b/src/utils/cli.cpp
@@ -106,7 +106,7 @@ void Utils::Cli::generateZshCompletionScript(const QList<QCommandLineOption>& op
             // Check if the option expects a value
             if (!option.valueName().isEmpty()) {
                 // Assume the value can be any string, for specifics you might need to adjust
-                optionPattern += QString("=") + "'[:" + option.description() + ":]'";
+                optionPattern += QStringLiteral("=") + "'[:" + option.description() + ":]'";
             } else {
                 optionPattern += "[:" + option.description() + ":]";
             }

--- a/src/utils/misc.cpp
+++ b/src/utils/misc.cpp
@@ -1196,7 +1196,7 @@ QDataStream &Utils::Misc::dataStreamWrite(QDataStream &os, const QPrinter &print
     os << margins.left() << margins.top() << margins.right() << margins.bottom();
 
     Q_ASSERT_X(os.status() == QDataStream::Ok, __FUNCTION__,
-               QString("Stream status = %1").arg(os.status()).toStdString().c_str());
+               QStringLiteral("Stream status = %1").arg(os.status()).toStdString().c_str());
     return os;
 }
 
@@ -1254,7 +1254,7 @@ QDataStream &Utils::Misc::dataStreamRead(QDataStream &is, QPrinter &printer) {
     printer.setPageMargins(margins, QPageLayout::Unit::Millimeter);
 
     Q_ASSERT_X(is.status() == QDataStream::Ok, __FUNCTION__,
-               QString("Stream status = %1").arg(is.status()).toStdString().c_str());
+               QStringLiteral("Stream status = %1").arg(is.status()).toStdString().c_str());
 
     return is;
 }
@@ -1505,11 +1505,11 @@ QString Utils::Misc::toHumanReadableByteSize(qint64 size) {
 
     // Handle special case for bytes
     if (unitIndex == 0) {
-        return QString("%1 %2").arg(size).arg(units[unitIndex]);
+        return QStringLiteral("%1 %2").arg(size).arg(units[unitIndex]);
     }
 
     // Use QString::number for better performance and more control
-    return QString("%1 %2").arg(QString::number(num, 'f', 2), units[unitIndex]);
+    return QStringLiteral("%1 %2").arg(QString::number(num, 'f', 2), units[unitIndex]);
 }
 
 /**
@@ -1962,7 +1962,7 @@ void Utils::Misc::transformNextcloudPreviewImages(QString &html, int maxImageWid
         }
 
         imageWidth = std::min(maxImageWidth, imageWidth);
-        inlineImageTag.replace("/>", QString("width=\"%1\"/>").arg(QString::number(imageWidth)));
+        inlineImageTag.replace("/>", QStringLiteral("width=\"%1\"/>").arg(QString::number(imageWidth)));
 
         html.replace(imageTag, inlineImageTag);
     }
@@ -2000,7 +2000,7 @@ void Utils::Misc::transformRemotePreviewImages(QString &html, int maxImageWidth,
         }
 
         imageWidth = std::min(maxImageWidth, imageWidth);
-        inlineImageTag.replace(">", QString("width=\"%1\">").arg(QString::number(imageWidth)));
+        inlineImageTag.replace(">", QStringLiteral("width=\"%1\">").arg(QString::number(imageWidth)));
         html.replace(imageTag, inlineImageTag);
     }
 }

--- a/src/widgets/notefilepathlabel.cpp
+++ b/src/widgets/notefilepathlabel.cpp
@@ -55,7 +55,7 @@ void NoteFilePathLabel::updateText() {
 
     const NoteSubFolder noteSubFolder = note.getNoteSubFolder();
     if (noteSubFolder.isFetched()) {
-        notePath.prepend(QString("<span style='color: %1;'>%2</span>%3")
+        notePath.prepend(QStringLiteral("<span style='color: %1;'>%2</span>%3")
                              .arg(subFolderColor,
                                   Utils::Misc::htmlspecialchars(noteSubFolder.relativePath()),
                                   QString(separator)));
@@ -73,7 +73,7 @@ void NoteFilePathLabel::updateText() {
         }
 #endif
 
-        notePath.prepend(QString("<span style='color: %1;'>%2</span>%3")
+        notePath.prepend(QStringLiteral("<span style='color: %1;'>%2</span>%3")
                              .arg(noteFolderColor, Utils::Misc::htmlspecialchars(noteFolderPath),
                                   QString(separator)));
     }

--- a/src/widgets/qownnotesmarkdowntextedit.cpp
+++ b/src/widgets/qownnotesmarkdowntextedit.cpp
@@ -393,7 +393,7 @@ void QOwnNotesMarkdownTextEdit::setPaperMargins(int width) {
                 // set the size of characterAmount times the size of "O"
                 // characters
 #if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
-            int proposedEditorWidth = metrics.width(QString("O").repeated(characterAmount));
+            int proposedEditorWidth = metrics.width(QStringLiteral("O").repeated(characterAmount));
 #else
             int proposedEditorWidth =
                 metrics.horizontalAdvance(QStringLiteral("O").repeated(characterAmount));


### PR DESCRIPTION
- Qt provides a macro [QStringLiteral()](https://doc.qt.io/qt-6/qstring.html#QStringLiteral), which makes constructing QString objects from string literals more efficient.