### PR TITLE
Feature/gdscript highlighting

### DIFF
--- a/src/helpers/codetohtmlconverter.cpp
+++ b/src/helpers/codetohtmlconverter.cpp
@@ -51,7 +51,8 @@ void CodeToHtmlConverter::initCodeLangs() Q_DECL_NOTHROW {
         {QStringLiteral("yml"), CodeToHtmlConverter::CodeYAML},
         {QStringLiteral("yaml"), CodeToHtmlConverter::CodeYAML},
         {QStringLiteral("forth"), CodeToHtmlConverter::CodeForth},
-        {QStringLiteral("systemverilog"), CodeToHtmlConverter::CodeSystemVerilog}};
+        {QStringLiteral("systemverilog"), CodeToHtmlConverter::CodeSystemVerilog},
+        {QStringLiteral("gdscript"), CodeToHtmlConverter::CodeGDScript}};
 }
 
 QString CodeToHtmlConverter::process(const QString &input) const {
@@ -159,6 +160,10 @@ QString CodeToHtmlConverter::process(StringView input) const {
             break;
         case CodeSystemVerilog:
             loadSystemVerilogData(types, keywords, builtin, literals, others);
+            break;
+        case CodeGDScript:
+            loadGDScriptData(types, keywords, builtin, literals, others);
+            comment = QLatin1Char('#');
             break;
         default:
             output += escapeString(input);

--- a/src/helpers/codetohtmlconverter.h
+++ b/src/helpers/codetohtmlconverter.h
@@ -51,7 +51,8 @@ class CodeToHtmlConverter {
         CodeMake,
         CodeNix,
         CodeForth,
-        CodeSystemVerilog
+        CodeSystemVerilog,
+        CodeGDScript
     };
 
    public:


### PR DESCRIPTION
Pulled data from the following pages from the Godot documentation: 

[All Classes](https://docs.godotengine.org/en/stable/classes/index.html) 
[@GDScript](https://docs.godotengine.org/en/stable/classes/class_%40gdscript.html) 
[@GlobalScope](https://docs.godotengine.org/en/stable/classes/class_%40globalscope.html) 
[GDScript reference](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_basics.html)

Worth noting:
[markdownhighlighter.cpp](https://github.com/pbek/qmarkdowntextedit/compare/develop...DarienMC:qmarkdowntextedit:feature/gdscript_highlighting?expand=1#diff-36d2a396db7785575ce4d5b3993e00a566c113d0245a20ae1ee53a903482a0d3)
The method `void MarkdownHighlighter::gdscriptHighlighter(const QString &text)` on line 1717 was created to highlight three items after making use of the existing highlighting systems in place took care of most of it:
1. Highlight `$NodePath` constructs. On GitHub's markdown, it is a little lazy as it only highlights the '$' symbol. My implementation is just as lazy, unfortunately. Ideally, we'd want the whole symbol `$NodePath` to be highlighted like we see in the latest version of Godot Engine 4.3 as seen with the `$AnimationPlayer` below. This likely involves seeking spaces, or periods, or newlines, etc. that I didn't do.
![image](https://github.com/user-attachments/assets/b71e13a8-b0f6-4172-a6e7-7f1480bc05ef)
2. Highlight `%UniqueNote` constructs. Same issue as above, but with the '%' symbol.
3. Highlight `@` annotations. So this one is a little weird. I thought it would be sufficient to use the '@' symbol in the language data found in the [qownlanguagedata.cpp](https://github.com/pbek/qmarkdowntextedit/compare/develop...DarienMC:qmarkdowntextedit:feature/gdscript_highlighting?expand=1#diff-2b84467cd1f387ec26227a2be4a6163e7922a78ed04e48cd7b6a207cd7feaf0f) file as an "Other" format. However, the default highlighting does not seem to highlight any `{('@'), QLatin1String("@string")},`. I'm not sure why, but the work-around was to simply add valid annotations in the language data without their '@' symbol, then highlight the '@' on its own.
