### PR TITLE
Modified gentoo ebuild template to build against qt6

### DIFF
--- a/build-systems/gentoo/build-for-gentoo.sh
+++ b/build-systems/gentoo/build-for-gentoo.sh
@@ -64,8 +64,14 @@ ARCHIVE_FILE=qownnotes-${QOWNNOTES_VERSION}.tar.xz
 cd ../overlay/app-office/qownnotes/ || exit 1
 cp ../../../QOwnNotes/build-systems/gentoo/qownnotes.ebuild .
 
-# replace the version in the ebuild file
-sed -i "s/VERSION-STRING/$QOWNNOTES_VERSION/g" qownnotes.ebuild
+# create metadata file
+echo '<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+        <upstream>
+                <remote-id type="github">pbek/QOwnNotes</remote-id>
+        </upstream>
+</pkgmetadata>' >metadata.xml
 
 # update the Manifest file
 echo "DIST ${ARCHIVE_FILE} ${QOWNNOTES_ARCHIVE_SIZE} SHA512 ${QOWNNOTES_ARCHIVE_SHA512}" >>Manifest
@@ -75,7 +81,7 @@ mv qownnotes.ebuild ${eBuildFile}
 
 echo "Committing changes..."
 git add ${eBuildFile}
-git commit -m "releasing version $QOWNNOTES_VERSION" ${eBuildFile} Manifest
+git commit -m "releasing version $QOWNNOTES_VERSION" ${eBuildFile} Manifest metadata.xml
 git push
 
 # remove everything after we are done

--- a/build-systems/gentoo/build-for-gentoo.sh
+++ b/build-systems/gentoo/build-for-gentoo.sh
@@ -90,15 +90,7 @@ ARCHIVE_FILE=qownnotes-${QOWNNOTES_VERSION}.tar.xz
 
 cd ../overlay/app-office/qownnotes/ || exit 1
 cp ../../../QOwnNotes/build-systems/gentoo/qownnotes.ebuild .
-
-# create metadata file
-echo '<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
-<pkgmetadata>
-        <upstream>
-                <remote-id type="github">pbek/QOwnNotes</remote-id>
-        </upstream>
-</pkgmetadata>' >metadata.xml
+cp ../../../QOwnNotes/build-systems/gentoo/metadata.xml .
 
 ebuilds_to_delete="$(list_old_ebuilds_to_delete)"
 

--- a/build-systems/gentoo/build-for-gentoo.sh
+++ b/build-systems/gentoo/build-for-gentoo.sh
@@ -36,6 +36,33 @@ if [ -z ${QOWNNOTES_ARCHIVE_SIZE} ]; then
   exit 1
 fi
 
+list_old_ebuilds_to_delete() {
+  all_files=($(find . -maxdepth 1 -type f -name 'qownnotes-*.ebuild' -printf '%f\n'))
+  majors=$(printf '%s\n' "${all_files[@]}" | sed -E 's/^qownnotes-([0-9]+)\..*/\1/' | sort -u)
+  latest_major=$(printf '%s\n' $majors | sort -n | tail -n 1)
+  to_delete=()
+
+  for major in ${majors}; do
+    files=($(printf '%s\n' "${all_files[@]}" | grep "^qownnotes-${major}\." | sort -V))
+
+    if [[ $major -eq $latest_major ]]; then
+      # Keep the last 3 for latest major
+      if (( ${#files[@]} > 3 )); then
+        to_delete+=("${files[@]:0:${#files[@]}-3}")
+      fi
+    else
+      # Keep only the last one for older majors
+      if (( ${#files[@]} > 1 )); then
+        to_delete+=("${files[@]:0:${#files[@]}-1}")
+      fi
+    fi
+  done
+
+  if [[ ${#to_delete[@]} -gt 0 ]]; then
+    printf '%s ' "${to_delete[@]}"
+  fi
+}
+
 echo "Started the ebuild packaging process, using latest '$BRANCH' git tree"
 
 if [ -d $PROJECT_PATH ]; then
@@ -73,6 +100,16 @@ echo '<?xml version="1.0" encoding="UTF-8"?>
         </upstream>
 </pkgmetadata>' >metadata.xml
 
+ebuilds_to_delete="$(list_old_ebuilds_to_delete)"
+
+# Remove to-be-deleted versions from Manifest
+read -r -a ebuilds_to_delete_array <<< ${ebuilds_to_delete}
+patterns=$(for f in "${ebuilds_to_delete_array[@]}"; do
+  base=${f%.ebuild}
+  echo "DIST ${base}.tar.xz"
+done)
+grep -vF -f <(printf '%s\n' "$patterns") Manifest > Manifest.new && mv Manifest.new Manifest
+
 # update the Manifest file
 echo "DIST ${ARCHIVE_FILE} ${QOWNNOTES_ARCHIVE_SIZE} SHA512 ${QOWNNOTES_ARCHIVE_SHA512}" >>Manifest
 
@@ -80,8 +117,9 @@ eBuildFile="qownnotes-$QOWNNOTES_VERSION.ebuild"
 mv qownnotes.ebuild ${eBuildFile}
 
 echo "Committing changes..."
+[ -n "${ebuilds_to_delete}" ] && git rm ${ebuilds_to_delete}
 git add ${eBuildFile}
-git commit -m "releasing version $QOWNNOTES_VERSION" ${eBuildFile} Manifest metadata.xml
+git commit -m "releasing version $QOWNNOTES_VERSION" ${eBuildFile} Manifest metadata.xml ${ebuilds_to_delete}
 git push
 
 # remove everything after we are done

--- a/build-systems/gentoo/metadata.xml
+++ b/build-systems/gentoo/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+        <upstream>
+                <remote-id type="github">pbek/QOwnNotes</remote-id>
+        </upstream>
+</pkgmetadata>

--- a/build-systems/gentoo/qownnotes.ebuild
+++ b/build-systems/gentoo/qownnotes.ebuild
@@ -6,7 +6,7 @@
 # QOwnNotes VERSION-STRING
 #
 
-EAPI=7
+EAPI=8
 
 inherit qmake-utils desktop xdg-utils
 
@@ -28,7 +28,7 @@ src_prepare() {
 }
 
 src_compile() {
-	eqmake5 QOwnNotes.pro -r
+	eqmake6 QOwnNotes.pro -r
 }
 
 src_install() {

--- a/build-systems/gentoo/qownnotes.ebuild
+++ b/build-systems/gentoo/qownnotes.ebuild
@@ -1,10 +1,7 @@
-# Copyright 2014-2025 Patrizio Bekerle, Patrick Nagel
+# Copyright 2014-2021 Patrizio Bekerle
+# Copyright 2025 Patrick Nagel
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
-
-#
-# QOwnNotes VERSION-STRING
-#
 
 EAPI=8
 
@@ -16,10 +13,9 @@ SRC_URI="https://github.com/pbek/QOwnNotes/releases/download/v${PV}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="~x86 ~amd64"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
 
-DEPEND=">=dev-qt/qtbase-6.7.2:6[gui]"
+DEPEND=">=dev-qt/qtbase-6.9:6[widgets,gui,concurrent,sql,network,xml]"
 RDEPEND="${DEPEND}"
 
 src_prepare() {
@@ -35,12 +31,9 @@ src_install() {
 	emake
 	dobin QOwnNotes
 
-	dodir /usr/share/qt6/translations
 	insinto /usr/share/qt6/translations
-
 	doins languages/*.qm
 
-	insinto /usr/share/applications
 	doicon -s 128 "images/icons/128x128/apps/QOwnNotes.png"
 	doicon -s 16 "images/icons/16x16/apps/QOwnNotes.png"
 	doicon -s 24 "images/icons/24x24/apps/QOwnNotes.png"
@@ -51,7 +44,8 @@ src_install() {
 	doicon -s 64 "images/icons/64x64/apps/QOwnNotes.png"
 	doicon -s 96 "images/icons/96x96/apps/QOwnNotes.png"
 	doicon -s scalable "images/icons/scalable/apps/QOwnNotes.svg"
-	doins PBE.QOwnNotes.desktop
+
+	domenu PBE.QOwnNotes.desktop
 }
 
 pkg_postinst() {

--- a/build-systems/gentoo/qownnotes.ebuild
+++ b/build-systems/gentoo/qownnotes.ebuild
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 Patrizio Bekerle
+# Copyright 2014-2025 Patrizio Bekerle, Patrick Nagel
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -12,27 +12,14 @@ inherit qmake-utils desktop xdg-utils
 
 DESCRIPTION="A plain-text file markdown note taking with Nextcloud/ownCloud integration"
 HOMEPAGE="https://www.qownnotes.org/"
-SRC_URI="https://github.com/pbek/QOwnNotes/releases/download/vVERSION-STRING/${P}.tar.xz"
+SRC_URI="https://github.com/pbek/QOwnNotes/releases/download/v${PV}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~x86 ~amd64"
 IUSE=""
 
-DEPEND="
-	dev-qt/qtwidgets:5
-	dev-qt/qtgui:5
-	dev-qt/qtcore:5
-	dev-qt/qtconcurrent:5
-	dev-qt/qtsql:5
-	dev-qt/qtsvg:5
-	dev-qt/qtnetwork:5
-	dev-qt/qtdeclarative:5
-	dev-qt/qtxml:5
-	dev-qt/qtprintsupport:5
-	dev-qt/qtwebsockets:5
-	dev-qt/qtx11extras:5
-"
+DEPEND=">=dev-qt/qtbase-6.7.2:6[gui]"
 RDEPEND="${DEPEND}"
 
 src_prepare() {
@@ -48,8 +35,8 @@ src_install() {
 	emake
 	dobin QOwnNotes
 
-	dodir /usr/share/qt5/translations
-	insinto /usr/share/qt5/translations
+	dodir /usr/share/qt6/translations
+	insinto /usr/share/qt6/translations
 
 	doins languages/*.qm
 


### PR DESCRIPTION
- Modernize ebuild and switch from qt5 to qt6
- In build-for-gentoo.sh add functionality to keep only one ebuild per major version (except for the latest major version, where it keeps three) and also maintain the Manifest accordingly.