### PR TITLE
Added missing Qt6 dependencies

### DIFF
--- a/build-systems/gentoo/qownnotes.ebuild
+++ b/build-systems/gentoo/qownnotes.ebuild
@@ -15,7 +15,12 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-DEPEND=">=dev-qt/qtbase-6.9:6[widgets,gui,concurrent,sql,network,xml]"
+DEPEND="
+>=dev-qt/qtbase-6.9:6[widgets,gui,concurrent,sql,network,xml]
+>=dev-qt/qtwebsockets-6.9:6
+>=dev-qt/qtdeclarative-6.9:6
+>=dev-qt/qtsvg-6.9:6
+"
 RDEPEND="${DEPEND}"
 
 src_prepare() {


### PR DESCRIPTION
I had mistakenly thought websockets, declarative and svg were also part of qtbase now, like widgets, gui, concurrent, sql, network and xml. But they aren't. This PR should fix the build for systems where any of qtwebsockes, qtdeclarative or qtsvg is not installed.