### PR TITLE
Use newer SlackBuild template, switch to CMake, add 15.0 directory

### DIFF
--- a/build-systems/slackware/build-for-slackware.sh
+++ b/build-systems/slackware/build-for-slackware.sh
@@ -75,8 +75,14 @@ cp qownnotes.SlackBuild ${path14_2}
 cp qownnotes.info ${path14_2}
 cp dobuild.sh ${path14_2}
 
+path15_0="../../15.0/qownnotes"
+cp qownnotes.SlackBuild ${path15_0}
+cp qownnotes.info ${path15_0}
+sed -i 's/REQUIRES="qt5 libproxy"/REQUIRES=""/' ${path15_0}/qownnotes.info
+cp dobuild.sh ${path15_0}
+
 echo "Committing changes..."
-git commit -m "releasing version $QOWNNOTES_VERSION" * ${path14_2}/*
+git commit -m "releasing version $QOWNNOTES_VERSION" * ${path14_2}/* ${path15_0}/*
 git push
 
 # remove everything after we are done

--- a/build-systems/slackware/qownnotes.SlackBuild
+++ b/build-systems/slackware/qownnotes.SlackBuild
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 # Slackware build script for qownnotes
 
-# Copyright 2014-2021 Patrizio Bekerle (patrizio@bekerle.com)
+# Copyright 2014-2025 Patrizio Bekerle (patrizio@bekerle.com)
 # All rights reserved.
 #
 # Redistribution and use of this script, with or without modification, is
@@ -22,36 +22,41 @@
 #  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 #  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+cd $(dirname $0) ; CWD=$(pwd)
+
 PRGNAM=qownnotes
 VERSION=${VERSION:-VERSION-STRING}
 BUILD=${BUILD:-1}
-TAG=${TAG:-_SBo}
+TAG=${TAG:-pbek}
+PKGTYPE=${PKGTYPE:-tgz}
 
 if [ -z "$ARCH" ]; then
   case "$( uname -m )" in
-    i?86) ARCH=i486 ;;
+    i?86) ARCH=i586 ;;
     arm*) ARCH=arm ;;
        *) ARCH=$( uname -m ) ;;
   esac
 fi
 
-CWD=$(pwd)
+if [ ! -z "${PRINT_PACKAGE_NAME}" ]; then
+  echo "$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE"
+  exit 0
+fi
+
 TMP=${TMP:-/tmp/SBo}
 PKG=$TMP/package-$PRGNAM
 OUTPUT=${OUTPUT:-/tmp}
 
-if [ "$ARCH" = "i486" ]; then
-  SLKCFLAGS="-O2 -march=i486 -mtune=i686"
-  LIBDIRSUFFIX=""
+if [ "$ARCH" = "i586" ]; then
+  SLKCFLAGS="-O2 -march=i586 -mtune=i686"
 elif [ "$ARCH" = "i686" ]; then
   SLKCFLAGS="-O2 -march=i686 -mtune=i686"
-  LIBDIRSUFFIX=""
 elif [ "$ARCH" = "x86_64" ]; then
   SLKCFLAGS="-O2 -fPIC"
-  LIBDIRSUFFIX="64"
+elif [ "$ARCH" = "aarch64" ]; then
+  SLKCFLAGS="-O2 -fPIC"
 else
   SLKCFLAGS="-O2"
-  LIBDIRSUFFIX=""
 fi
 
 set -e
@@ -60,13 +65,7 @@ rm -rf $PKG
 mkdir -p $TMP $PKG $OUTPUT
 cd $TMP
 rm -rf $PRGNAM-$VERSION
-
-if [ -e $CWD/v$VERSION.tar.xz ] ; then
-  tar xvf $CWD/v$VERSION.tar.xz
-else
-  tar xvf $CWD/$PRGNAM-$VERSION.tar.xz
-fi
-
+tar xvf $CWD/$PRGNAM-$VERSION.tar.xz
 cd $PRGNAM-$VERSION
 chown -R root:root .
 find -L . \
@@ -76,17 +75,26 @@ find -L . \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
 # Set the release string to disable the update check
-echo "#define RELEASE \"SlackBuild\"" > release.h
+echo '#define RELEASE "SlackBuild"' > release.h
 
-qmake-qt5
-make
-make INSTALL_ROOT=$PKG install
+mkdir build
+CFLAGS="$SLKCFLAGS" \
+CXXFLAGS="$SLKCFLAGS" \
+cmake \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DBUILD_WITH_ASPELL=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -B build
+cmake --build build
+DESTDIR=$PKG cmake --install build
 
 find $PKG -print0 | xargs -0 file | grep -e "executable" -e "shared object" | grep ELF \
   | cut -f 1 -d : | xargs strip --strip-unneeded 2> /dev/null || true
 
 mkdir -p $PKG/usr/doc/$PRGNAM-$VERSION
-cp -a CHANGELOG.md LICENSE README.md shortcuts.md $PKG/usr/doc/$PRGNAM-$VERSION
+cp -a \
+  CHANGELOG.md LICENSE README.md shortcuts.md \
+  $PKG/usr/doc/$PRGNAM-$VERSION
 cat $CWD/$PRGNAM.SlackBuild > $PKG/usr/doc/$PRGNAM-$VERSION/$PRGNAM.SlackBuild
 
 mkdir -p $PKG/install
@@ -94,4 +102,4 @@ cat $CWD/slack-desc > $PKG/install/slack-desc
 cat $CWD/doinst.sh > $PKG/install/doinst.sh
 
 cd $PKG
-/sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.${PKGTYPE:-tgz}
+/sbin/makepkg -l y -c n $OUTPUT/$PRGNAM-$VERSION-$ARCH-$BUILD$TAG.$PKGTYPE


### PR DESCRIPTION
A complementary change to the update of [qownnotes-slackbuilds](https://github.com/pbek/qownnotes-slackbuilds) repo. Can't test it since I don't have your pipeline, but hopefully it'll work. Also no idea if 12 year old CMake from Slackware 14.1 can build this, probably not, so that's where my point of separation of templates comes from.

Sorry for such a lazy PR, don't really have time right now to entirely rework the approach to SlackBuilds, I just needed to push this so my changes to the qownnotes-slackbuilds repo don't disappear during the next release. I'll probably send a better PR at a later date, the one that adds support for building in -current with Qt6.