### PR TITLE
delete language files located in root directory of install during update

### DIFF
--- a/appveyor/update.bat
+++ b/appveyor/update.bat
@@ -38,6 +38,9 @@ echo Deleting temporary files
 del %source%
 del %unzipExecutable%
 echo ======================================
+echo Deleting language files in root dir
+del /Q %destination%\*.qm
+echo ======================================
 echo Starting QOwnNotes:
 echo %qownnotesCommand%
 rem start in background


### PR DESCRIPTION
When `update.bat` is run during an update, this code removes all language files (with a QM file extension) from the root directory.

Depends on #3435.