### PR TITLE
[Qt6] create 'languages' subdirectory for QM files

### DIFF
--- a/build-systems/github/windows/build-zip-qt6.ps1
+++ b/build-systems/github/windows/build-zip-qt6.ps1
@@ -15,8 +15,8 @@ qmake6 CONFIG+=release QOwnNotes.pro -r
 lrelease QOwnNotes.pro
 set CL=/MP
 nmake
-# Create release directory
-New-Item -Path '..\release' -ItemType 'Directory'
+# Create release directory and languages subdirectory
+New-Item -Path '..\release\languages' -ItemType 'Directory' -Force
 # copy the binary to our release path
 Copy-Item release\QOwnNotes.exe ..\release
 # copy Win64 OpenSSL v1.1.1g DLLs to the release path
@@ -28,8 +28,8 @@ Copy-Item ..\appveyor\unzip.exe ..\release
 Copy-Item ..\appveyor\update.bat ..\release
 # copy portable mode launcher to the release path
 Copy-Item ..\appveyor\QOwnNotesPortable.bat ..\release
-# copy translation files
-Copy-Item languages\*.qm ..\release
+# copy translation files into languages subdirectory
+Copy-Item languages\*.qm ..\release\languages
 Set-Location ..\release
 # Fetching dependencies of QT app
 # https://doc.qt.io/qt-6/windows-deployment.html


### PR DESCRIPTION
1. a new `languages` subdirectory is created under the `release` directory (line 19)
2. the translation files (*.QM) are copied into `languages` instead of the root directory (line 32)