### PR TITLE
Update Fedora installation instructions (for F41 and later)

### DIFF
--- a/webpage/src/installation/fedora.md
+++ b/webpage/src/installation/fedora.md
@@ -10,6 +10,18 @@ For most users you can just use `dnf install qownnotes` in a terminal window to 
 If you want the **most up-to-date version**, please continue reading.
 :::
 
+## On systems with Fedora 41 and higher
+
+Starting with [Fedora 41](https://fedoraproject.org/wiki/Changes/SwitchToDnf5), dnf5 is the default package manager and includes the config-manager plugin by default. Run the following commands as root to add the repository and install QOwnNotes:
+
+```bash
+dnf config-manager add-repo --from-repofile=https://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Fedora_42/home:pbek:QOwnNotes.repo
+
+dnf install qownnotes
+```
+
+Change the portion `Fedora_42` in the above code with the version of Fedora you are using (i.e. `Fedora_41`, `Fedora_Rawhide` etc.).
+
 ## On systems with config-manager dnf plugin
 
 Run the following shell commands as root to add the repository.


### PR DESCRIPTION
Hello! I created this pull request to fix the installation instructions for QOwnNotes on Fedora 41 and later. Starting with Fedora 41, dnf5 is used as the default package manager. The former config-manager plugin is now a built-in subcommand, with slightly different command-line flags.
