### PR TITLE
Fix building against Qt6 in presence of Qt5

### DIFF
--- a/src/libraries/qlitehtml/CMakeLists.txt
+++ b/src/libraries/qlitehtml/CMakeLists.txt
@@ -27,10 +27,6 @@ else()
 endif()
 
 find_package(
-  QT 5.11 NAMES Qt6 Qt5
-  COMPONENTS Widgets
-  REQUIRED)
-find_package(
   Qt${QT_VERSION_MAJOR}
   COMPONENTS Widgets
   REQUIRED)


### PR DESCRIPTION
On systems with both Qt6 and Qt5 present (in my case, Slackware 15.0) building QOwnNotes against Qt6 fails with this error:

```
Using Qt version 6
-- Found Cups: /usr/lib64/libcups.so (found version "2.4.16")
-- ccache found
-- Configuring done (4.2s)
CMake Error: The INTERFACE_QT_MAJOR_VERSION property of "Qt5::Core" does
not agree with the value of QT_MAJOR_VERSION already determined
for "QOwnNotes".
```

I managed to find the culprit: qlitehtml. Its CMakeLists.txt looks specifically for Qt5 first despite explicitly requiring Qt6. Removing the first instance of find_package() should be fine as QT_VERSION_MAJOR is defined by the parent CMakeLists.txt.

After this change both Qt6 and Qt5 versions build with no issues on a system with both Qt6 and Qt5 present.