### PR TITLE
Allow `just src-run` to work on macOS

### DIFF
--- a/justfile
+++ b/justfile
@@ -143,7 +143,11 @@ src-clean:
 # Run the built application
 [group('src-build')]
 src-run:
-    ./{{ sourceBuildDir }}/QOwnNotes
+    @if [ "$(uname)" = "Darwin" ]; then \
+        ./{{ sourceBuildDir }}/QOwnNotes.app/Contents/MacOS/QOwnNotes; \
+    else \
+        ./{{ sourceBuildDir }}/QOwnNotes; \
+    fi
 
 # Build and run the application
 [group('src-build')]


### PR DESCRIPTION
On macOS, a `QOwnNotes.app` is built, so the current command does launch it.