### PR TITLE
Do not delete existing settings and database when closing welcome dialog

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -351,9 +351,6 @@ int mainStartupMisc(const QStringList &arguments) {
         WelcomeDialog welcomeDialog;
         // exit QOwnNotes if the welcome dialog was canceled
         if (welcomeDialog.exec() != QDialog::Accepted) {
-            settings.clear();
-            DatabaseService::removeDiskDatabase();
-
             return 0;
         }
     }


### PR DESCRIPTION
On macOS, it is possible that there is an issue reading the settings file. This will cause the welcome dialog to be shown, which deletes the existing settings and database when closed.

I haven't been able to find the root cause of this issue (#3548). For some reason, it doesn't seem to happen with debug builds. 😢 

This PR makes sure that the settings are at least preserved...