### PR TITLE
Add menu option to rename current note

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2400,8 +2400,6 @@ void MainWindow::readSettings() {
         on_actionAllow_note_editing_triggered(isAllowNoteEditing);
     }
 
-    ui->action_Rename_note->setVisible(Note::allowDifferentFileName());
-
     // we want to trigger the event afterward so the settings of the note edits
     // are updated
     const bool centerCursor = settings.value(QStringLiteral("Editor/centerCursor")).toBool();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2400,6 +2400,8 @@ void MainWindow::readSettings() {
         on_actionAllow_note_editing_triggered(isAllowNoteEditing);
     }
 
+    ui->action_Rename_note->setVisible(Note::allowDifferentFileName());
+
     // we want to trigger the event afterward so the settings of the note edits
     // are updated
     const bool centerCursor = settings.value(QStringLiteral("Editor/centerCursor")).toBool();
@@ -2618,6 +2620,8 @@ void MainWindow::readSettingsFromSettingsDialog(const bool isAppLaunch) {
     ui->actionShow_note_git_versions->setVisible(Utils::Git::hasLogCommand());
     ui->actionShow_note_git_versions_external->setVisible(false);
 #endif
+
+    ui->action_Rename_note->setVisible(Note::allowDifferentFileName());
 
     // show or hide 'Find or create ...' search in Note Subfolders & Tags Panels
     ui->noteSubFolderLineEdit->setHidden(
@@ -4417,6 +4421,8 @@ void MainWindow::on_actionAbout_QOwnNotes_triggered() {
 void MainWindow::on_action_New_note_triggered() {
     _noteOperationsManager->on_action_New_note_triggered();
 }
+
+void MainWindow::on_action_Rename_note_triggered() { _noteTreeManager->renameCurrentNote(); }
 
 /**
  * Creates a new note

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -360,6 +360,8 @@ class MainWindow : public QMainWindow {
 
     void on_action_New_note_triggered();
 
+    void on_action_Rename_note_triggered();
+
     void onNotePreviewAnchorClicked(const QUrl &arg1);
 
     void on_actionCheck_for_updates_triggered();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1233,6 +1233,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
      </property>
     </widget>
     <addaction name="menuEditNote"/>
+    <addaction name="action_Rename_note"/>
     <addaction name="action_Remove_note"/>
     <addaction name="separator"/>
     <addaction name="action_Find_text_in_note"/>
@@ -1495,6 +1496,15 @@ li.checked::marker { content: &quot;\2612&quot;; }
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+N</string>
+   </property>
+  </action>
+  <action name="action_Rename_note">
+   <property name="icon">
+    <iconset theme="document-edit" resource="breeze-qownnotes.qrc">
+     <normaloff>:/icons/breeze-qownnotes/16x16/document-edit.svg</normaloff>:/icons/breeze-qownnotes/16x16/document-edit.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Rename current note</string>
    </property>
   </action>
   <action name="actionCheck_for_updates">

--- a/src/managers/notetreemanager.cpp
+++ b/src/managers/notetreemanager.cpp
@@ -591,38 +591,45 @@ void NoteTreeManager::openNotesContextMenu(const QPoint globalPos, bool hasNotes
             // Reload the note list to update the icon and sorting
             _mainWindow->loadNoteDirectoryList();
         } else if (selectedItem == renameAction) {
-            QTreeWidgetItem *item = _ui->noteTreeWidget->currentItem();
+            renameCurrentNote();
+        }
+    }
+}
 
-            if (Note::allowDifferentFileName()) {
-                if (Utils::Misc::isNoteListPreview()) {
-                    bool ok{};
-                    const QString name = QInputDialog::getText(
-                        _mainWindow, tr("Rename note"), tr("Name:"), QLineEdit::Normal,
-                        _mainWindow->currentNote.getName(), &ok);
+void NoteTreeManager::renameCurrentNote() {
+    QTreeWidgetItem *item = _ui->noteTreeWidget->currentItem();
+    if (item == nullptr || item->data(0, Qt::UserRole + 1).toInt() != MainWindow::NoteType) {
+        return;
+    }
 
-                    if (ok && !name.isEmpty()) {
-                        item->setText(0, name);
-                        on_noteTreeWidget_itemChanged(item, 0);
-                    }
-                } else {
-                    _ui->noteTreeWidget->editItem(item);
-                }
-            } else {
-                QMessageBox msgBox(QMessageBox::Warning, tr("Note renaming not enabled!"),
-                                   tr("If you want to rename your note you have to enable "
-                                      "the option to allow the note filename to be "
-                                      "different from the headline."),
-                                   QMessageBox::NoButton, _mainWindow);
-                QPushButton *settingsButton =
-                    msgBox.addButton(tr("Open &settings"), QMessageBox::AcceptRole);
-                msgBox.addButton(tr("&Cancel"), QMessageBox::RejectRole);
-                msgBox.setDefaultButton(settingsButton);
-                msgBox.exec();
+    if (Note::allowDifferentFileName()) {
+        if (Utils::Misc::isNoteListPreview()) {
+            bool ok{};
+            const QString name =
+                QInputDialog::getText(_mainWindow, tr("Rename note"), tr("Name:"),
+                                      QLineEdit::Normal, _mainWindow->currentNote.getName(), &ok);
 
-                if (msgBox.clickedButton() == settingsButton) {
-                    _mainWindow->openSettingsDialog(SettingsDialog::NoteFolderPage);
-                }
+            if (ok && !name.isEmpty()) {
+                item->setText(0, name);
+                on_noteTreeWidget_itemChanged(item, 0);
             }
+        } else {
+            _ui->noteTreeWidget->editItem(item);
+        }
+    } else {
+        QMessageBox msgBox(QMessageBox::Warning, tr("Note renaming not enabled!"),
+                           tr("If you want to rename your note you have to enable "
+                              "the option to allow the note filename to be "
+                              "different from the headline."),
+                           QMessageBox::NoButton, _mainWindow);
+        QPushButton *settingsButton =
+            msgBox.addButton(tr("Open &settings"), QMessageBox::AcceptRole);
+        msgBox.addButton(tr("&Cancel"), QMessageBox::RejectRole);
+        msgBox.setDefaultButton(settingsButton);
+        msgBox.exec();
+
+        if (msgBox.clickedButton() == settingsButton) {
+            _mainWindow->openSettingsDialog(SettingsDialog::NoteFolderPage);
         }
     }
 }

--- a/src/managers/notetreemanager.cpp
+++ b/src/managers/notetreemanager.cpp
@@ -598,12 +598,21 @@ void NoteTreeManager::openNotesContextMenu(const QPoint globalPos, bool hasNotes
 
 void NoteTreeManager::renameCurrentNote() {
     QTreeWidgetItem *item = _ui->noteTreeWidget->currentItem();
+
+    // Fallback to the current note if no tree item is selected.
+    if (item == nullptr && _mainWindow->currentNote.isFetched()) {
+        item = findNoteInNoteTreeWidget(_mainWindow->currentNote);
+    }
+
     if (item == nullptr || item->data(0, Qt::UserRole + 1).toInt() != MainWindow::NoteType) {
         return;
     }
 
     if (Note::allowDifferentFileName()) {
-        if (Utils::Misc::isNoteListPreview()) {
+        const bool useInputDialog =
+            Utils::Misc::isNoteListPreview() || !_ui->notesListFrame->isVisible();
+
+        if (useInputDialog) {
             bool ok{};
             const QString name =
                 QInputDialog::getText(_mainWindow, tr("Rename note"), tr("Name:"),

--- a/src/managers/notetreemanager.h
+++ b/src/managers/notetreemanager.h
@@ -41,6 +41,7 @@ class NoteTreeManager : public QObject {
     int getSelectedNotesCount() const;
     QVector<Note> selectedNotes();
     void openNotesContextMenu(const QPoint globalPos, bool hasNotes, bool hasFolders = false);
+    void renameCurrentNote();
 
    public slots:
     void on_noteTreeWidget_currentItemChanged(QTreeWidgetItem *current, QTreeWidgetItem *previous);


### PR DESCRIPTION
Add 'Rename current note' menu option under 'Edit'. When selected, it will allow editing the name in the note list (if visible) or in a dialog otherwise. If 'Allow note file name to be different from headline' is disabled, the menu item will be hidden.

Here is a video showing the feature:

https://github.com/user-attachments/assets/856377ce-1cc6-40ee-9500-3c80caa1eeae

I read in the changelog that multiple directories can have a different 'Allow note file name to be different from headline' setting. That is one complication I have not considered.

Written with Copilot assistance.