### PR TITLE
misc: fix litehtml mingw-w64 build

### DIFF
--- a/src/libraries/qlitehtml/src/3rdparty/litehtml/include/litehtml/os_types.h
+++ b/src/libraries/qlitehtml/src/3rdparty/litehtml/include/litehtml/os_types.h
@@ -8,7 +8,7 @@ namespace litehtml {
 #if defined(WIN32) || defined(_WIN32) || defined(WINCE)
 
 // noexcept appeared since Visual Studio 2013
-#if _MSC_VER < 1900
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define noexcept
 #endif
 


### PR DESCRIPTION
The noexcept compat shim in os_types.h uses `#if _MSC_VER < 1900`. When building with clang on Windows, _MSC_VER is undefined and evaluates to 0, which is < 1900, so `noexcept` gets blanked out globally, breaking all of libc++. Guard it with `defined(_MSC_VER)` so it only fires for actual old MSVC.

---

Here is an example build log that failed: https://github.com/msys2/MINGW-packages/actions/runs/24926398391/job/72996953935?pr=29152#step:9:541