### PR TITLE
Fixed Typo in dnf Add Repo Line

### DIFF
--- a/webpage/src/installation/fedora.md
+++ b/webpage/src/installation/fedora.md
@@ -15,7 +15,7 @@ If you want the **most up-to-date version**, please continue reading.
 Starting with [Fedora 41](https://fedoraproject.org/wiki/Changes/SwitchToDnf5), dnf5 is the default package manager and includes the config-manager plugin by default. Run the following commands as root to add the repository and install QOwnNotes:
 
 ```bash
-dnf config-manager add-repo --from-repofile=https://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Fedora_42/home:pbek:QOwnNotes.repo
+dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Fedora_42/home:pbek:QOwnNotes.repo
 
 dnf install qownnotes
 ```


### PR DESCRIPTION
## Summary

dnf5 does not use `add-repo`, and instead uses `addrepo`. (https://dnf5.readthedocs.io/en/latest/dnf5_plugins/config-manager.8.html#subcommands)

## Checklist

- [X] I read the code contribution guidelines: https://www.qownnotes.org/contributing/code-contributions.html
- [X] I opened an issue first, or this pull request is for a trivial change such as a typo or a very small documentation fix
- [X] I created this pull request against the `main` branch
- [X] I created a separate branch for this work and did not open this pull request from my own `main` branch
- [X] I followed the repository's commit message style
- [X] This pull request does not edit translation files directly, or translation-related changes follow https://www.qownnotes.org/contributing/translation.html
