### PR TITLE
Fix Joplin RAW import silently skipping some attachments

### DIFF
--- a/src/dialogs/joplinimportdialog.cpp
+++ b/src/dialogs/joplinimportdialog.cpp
@@ -5,7 +5,10 @@
 #include <entities/tag.h>
 
 #include <QDebug>
+#include <QDir>
+#include <QFile>
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
 
@@ -402,8 +405,13 @@ void JoplinImportDialog::handleImages(Note& note, const QString& dirPath) {
     QString noteText = note.getNoteText();
 
     // Handle format: [![](:/imageId "hover text")]
+    //
+    // The label uses `(?:\\.|[^\]])*` instead of `[^\]]*` so that an escaped
+    // bracket (`\]`) inside the alt text -- common in web-clipped or OCR'd
+    // content -- doesn't prematurely end the capture and make the whole
+    // pattern fail to match.
     {
-        auto i = QRegularExpression(R"regex(!\[([^\]]*)\]\(:\/([\w\d]+)\s+"([^"]*)"\))regex")
+        auto i = QRegularExpression(R"regex(!\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\s+"([^"]*)"\))regex")
                      .globalMatch(noteText);
 
         while (i.hasNext()) {
@@ -421,7 +429,7 @@ void JoplinImportDialog::handleImages(Note& note, const QString& dirPath) {
 
     // Handle format: ![alt text](:/imageId)
     {
-        auto i = QRegularExpression(R"(!\[([^\]]*)\]\(:\/([\w\d]+)\))").globalMatch(noteText);
+        auto i = QRegularExpression(R"(!\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\))").globalMatch(noteText);
 
         while (i.hasNext()) {
             QRegularExpressionMatch match = i.next();
@@ -455,31 +463,24 @@ void JoplinImportDialog::importImage(Note& note, const QString& dirPath, QString
                                      const QString& imageName) {
     QString imageData = _imageData[imageId];
 
+    // Joplin resources are classified as image vs. attachment purely by their
+    // "mime:" field, but an `<img src=":/id">` tag can still point at a
+    // resource that wasn't classified as an image (e.g. a saved web-clipper
+    // page snapshot with `mime: text/html`). Fall back to the attachment
+    // data so we can still find and import the underlying file.
+    if (imageData.isEmpty()) {
+        imageData = _attachmentData[imageId];
+    }
+
     qDebug() << __func__ << " - 'imageName': " << imageName;
     qDebug() << __func__ << " - 'imageId': " << imageId;
     // qDebug() << __func__ << " - 'imageData': " << imageData;
 
-    QString fileExtension;
-    auto fileExtensionMatch =
-        QRegularExpression("^file_extension: (.+)$", QRegularExpression::MultilineOption)
-            .match(imageData);
-
-    if (fileExtensionMatch.hasMatch()) {
-        fileExtension = fileExtensionMatch.captured(1);
-    } else {
-        // if the extension wasn't set we'll try to get it from the original file
-        auto imageDataLines =
-            imageData.split(QRegularExpression(QStringLiteral(R"((\r\n)|(\n\r)|\r|\n)")));
-        auto originalFileName = imageDataLines[0];
-        auto fileInfo = QFileInfo(originalFileName);
-        fileExtension = fileInfo.suffix();
-    }
-
-    auto* mediaFile = new QFile(dirPath + "/resources/" + imageId + "." + fileExtension);
+    auto* mediaFile = findResourceFile(dirPath, imageId, imageData);
 
     qDebug() << __func__ << " - 'mediaFile': " << mediaFile;
 
-    if (!mediaFile->exists()) {
+    if (mediaFile == nullptr) {
         return;
     }
 
@@ -490,6 +491,64 @@ void JoplinImportDialog::importImage(Note& note, const QString& dirPath, QString
 }
 
 /**
+ * Resolves the on-disk resource file for a Joplin resource id.
+ *
+ * Joplin's raw export doesn't always populate the "file_extension:" field (or a
+ * usable original filename to derive it from) in a resource's metadata note --
+ * this is common for resources created by older Joplin versions or imported
+ * from other apps. When that happens we can't build the "<id>.<ext>" path from
+ * metadata alone, so as a last resort we look directly in the resources/
+ * directory for a file starting with the resource id.
+ *
+ * @param dirPath the Joplin export directory
+ * @param id the resource id
+ * @param metaData the resource's metadata note text (may be empty if the id
+ *                 wasn't found in either the image or attachment data at all)
+ * @return a QFile pointing at the resource, or nullptr if it can't be found
+ */
+QFile* JoplinImportDialog::findResourceFile(const QString& dirPath, const QString& id,
+                                            const QString& metaData) {
+    QString fileExtension;
+    auto fileExtensionMatch =
+        QRegularExpression("^file_extension: (.+)$", QRegularExpression::MultilineOption)
+            .match(metaData);
+
+    if (fileExtensionMatch.hasMatch()) {
+        fileExtension = fileExtensionMatch.captured(1);
+    } else if (!metaData.isEmpty()) {
+        // if the extension wasn't set we'll try to get it from the original file
+        auto metaDataLines =
+            metaData.split(QRegularExpression(QStringLiteral(R"((\r\n)|(\n\r)|\r|\n)")));
+        auto originalFileName = metaDataLines[0];
+        auto fileInfo = QFileInfo(originalFileName);
+        fileExtension = fileInfo.suffix();
+    }
+
+    if (!fileExtension.isEmpty()) {
+        auto* mediaFile = new QFile(dirPath + "/resources/" + id + "." + fileExtension);
+
+        if (mediaFile->exists()) {
+            return mediaFile;
+        }
+
+        delete mediaFile;
+    }
+
+    // Last resort: search the resources directory for a file that starts
+    // with the resource id, regardless of extension. Some resources (seen in
+    // the wild with an empty "mime:"/"file_extension:" combination) are
+    // exported with no extension at all, so the glob can't require a ".".
+    QDir resourceDir(dirPath + "/resources");
+    const QStringList matches = resourceDir.entryList(QStringList() << id + "*", QDir::Files);
+
+    if (!matches.isEmpty()) {
+        return new QFile(resourceDir.filePath(matches.first()));
+    }
+
+    return nullptr;
+}
+
+/**
  * Handle note attachments
  *
  * @param note
@@ -497,7 +556,18 @@ void JoplinImportDialog::importImage(Note& note, const QString& dirPath, QString
  */
 void JoplinImportDialog::handleAttachments(Note& note, const QString& dirPath) {
     QString noteText = note.getNoteText();
-    auto i = QRegularExpression(R"([^!](\[([^\]]*)\]\(:\/([\w\d]+)\)))").globalMatch(noteText);
+
+    // Use a zero-width negative lookbehind `(?<!!)` instead of a consuming
+    // `[^!]` character class. The consuming version eats whatever character
+    // precedes the link -- which is harmless for an isolated link, but when
+    // attachment links are packed back-to-back with no separator, e.g.
+    // `[a.pdf](:/id1)[b.pdf](:/id2)`, the closing `)` of the first link's
+    // match gets consumed as the "not an image" check for the first link,
+    // leaving no character left for the second link's check to consume, so
+    // every other link in the chain silently fails to match. The label also
+    // uses `(?:\\.|[^\]])*` instead of `[^\]]*` so an escaped bracket in the
+    // link text doesn't prematurely end the capture (see handleImages()).
+    auto i = QRegularExpression(R"((?<!!)(\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\)))").globalMatch(noteText);
 
     while (i.hasNext()) {
         QRegularExpressionMatch match = i.next();
@@ -506,30 +576,22 @@ void JoplinImportDialog::handleAttachments(Note& note, const QString& dirPath) {
         QString attachmentId = match.captured(3);
         QString attachmentData = _attachmentData[attachmentId];
 
+        // The attachment may actually be classified as an image (e.g. an
+        // image resource referenced via a plain `[label](:/id)` link instead
+        // of `![](:/id)`) -- fall back to the image data so we can still
+        // find and import the underlying file.
+        if (attachmentData.isEmpty()) {
+            attachmentData = _imageData[attachmentId];
+        }
+
         qDebug() << __func__ << " - 'attachmentName': " << attachmentName;
         qDebug() << __func__ << " - 'attachmentId': " << attachmentId;
 
-        QString fileExtension;
-        auto fileExtensionMatch =
-            QRegularExpression("^file_extension: (.+)$", QRegularExpression::MultilineOption)
-                .match(attachmentData);
-
-        if (fileExtensionMatch.hasMatch()) {
-            fileExtension = fileExtensionMatch.captured(1);
-        } else {
-            // if the extension wasn't set we'll try to get it from the original file
-            auto attachmentDataLines =
-                attachmentData.split(QRegularExpression(QStringLiteral(R"((\r\n)|(\n\r)|\r|\n)")));
-            auto originalFileName = attachmentDataLines[0];
-            auto fileInfo = QFileInfo(originalFileName);
-            fileExtension = fileInfo.suffix();
-        }
-
-        auto* mediaFile = new QFile(dirPath + "/resources/" + attachmentId + "." + fileExtension);
+        auto* mediaFile = findResourceFile(dirPath, attachmentId, attachmentData);
 
         qDebug() << __func__ << " - 'mediaFile': " << mediaFile;
 
-        if (!mediaFile->exists()) {
+        if (mediaFile == nullptr) {
             continue;
         }
 

--- a/src/dialogs/joplinimportdialog.cpp
+++ b/src/dialogs/joplinimportdialog.cpp
@@ -411,8 +411,9 @@ void JoplinImportDialog::handleImages(Note& note, const QString& dirPath) {
     // content -- doesn't prematurely end the capture and make the whole
     // pattern fail to match.
     {
-        auto i = QRegularExpression(R"regex(!\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\s+"([^"]*)"\))regex")
-                     .globalMatch(noteText);
+        auto i =
+            QRegularExpression(R"regex(!\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\s+"([^"]*)"\))regex")
+                .globalMatch(noteText);
 
         while (i.hasNext()) {
             QRegularExpressionMatch match = i.next();
@@ -429,7 +430,8 @@ void JoplinImportDialog::handleImages(Note& note, const QString& dirPath) {
 
     // Handle format: ![alt text](:/imageId)
     {
-        auto i = QRegularExpression(R"(!\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\))").globalMatch(noteText);
+        auto i =
+            QRegularExpression(R"(!\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\))").globalMatch(noteText);
 
         while (i.hasNext()) {
             QRegularExpressionMatch match = i.next();
@@ -567,7 +569,8 @@ void JoplinImportDialog::handleAttachments(Note& note, const QString& dirPath) {
     // every other link in the chain silently fails to match. The label also
     // uses `(?:\\.|[^\]])*` instead of `[^\]]*` so an escaped bracket in the
     // link text doesn't prematurely end the capture (see handleImages()).
-    auto i = QRegularExpression(R"((?<!!)(\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\)))").globalMatch(noteText);
+    auto i =
+        QRegularExpression(R"((?<!!)(\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\)))").globalMatch(noteText);
 
     while (i.hasNext()) {
         QRegularExpressionMatch match = i.next();

--- a/src/dialogs/joplinimportdialog.h
+++ b/src/dialogs/joplinimportdialog.h
@@ -10,6 +10,7 @@ class JoplinImportDialog;
 
 class Note;
 class QTreeWidgetItem;
+class QFile;
 
 class JoplinImportDialog : public MasterDialog {
     Q_OBJECT
@@ -50,4 +51,6 @@ class JoplinImportDialog : public MasterDialog {
     NoteSubFolder importFolder(const QString& id, const QString& text);
     void importImage(Note& note, const QString& dirPath, QString& noteText, const QString& imageTag,
                      const QString& imageId, const QString& imageName = "");
+    static QFile* findResourceFile(const QString& dirPath, const QString& id,
+                                   const QString& metaData);
 };


### PR DESCRIPTION
## Description

While migrating a personal note collection from Joplin to QOwnNotes using
the "Import notes from Joplin" RAW-export importer, I noticed a meaningful
share of attachments weren't showing up in the imported notes. There's no
warning or log entry when this happens — the only way to notice is to
compare attachment counts before and after import. Given the volume of
missing files, I had Claude Code run an analysis. It dug into
`src/dialogs/joplinimportdialog.cpp` to figure out why.

It found four separate places where a resource reference fails to resolve
and gets silently skipped instead of imported, and wrote this PR to fix all
four. I built and ran the patched importer against my own real export
(several thousand notes and resources, migrated over multiple Joplin
versions) as well as a small synthetic repro export (attached below), and
confirmed each fix resolves the case it targets.

## What this changes

### 1. Empty `file_extension` metadata isn't handled

Joplin resource metadata notes (`type_: 4`) normally carry the resource's
extension in a `file_extension:` field, with the note's own title as a
fallback source for deriving one. For resources created by older Joplin
versions, I found cases where **both** are empty, even though `mime:` is
set correctly and the underlying file exists on disk with the right
extension. The importer's fallback logic then derives an empty extension,
builds a path with a trailing dot and no suffix, and never finds the file.

**Fix:** factored resource-file resolution into a shared
`findResourceFile()` helper. When both `file_extension:` and the
derived-filename fallback come up empty, it globs the `resources/`
directory for anything starting with the resource id, instead of guessing
a single exact path.

### 2. `<img>` tags pointing at non-image-mime resources aren't found

Resources are bucketed into an "image" map or an "attachment" map purely by
mime prefix. Joplin's web clipper sometimes embeds a saved page snapshot
(`mime: text/html`) via an `<img>` tag, e.g.:

```html
<img width="32" height="32" src=":/347198f47fd0459081a9c14d573105b6"/>
```

The `<img>` regex matches this fine, but the lookup only checks the
"image" map — since this id was bucketed as an attachment, the lookup comes
back empty.

**Fix:** `importImage()` (and symmetrically `handleAttachments()`) now
falls back to the other map before giving up on an id.

### 3. Back-to-back attachment links can lose every other link

`handleAttachments()`'s regex used a *consuming* `[^!]` character class to
check that a link isn't actually an image reference, instead of a
zero-width lookbehind. When Joplin exports attachment links with no
separator between them (e.g. a note that's just a list of scanned
documents), the first link's match consumes the character the next link's
`[^!]` check needs, so the regex can't find a valid starting position for
it — silently dropping most links in dense chains.

**Fix:** changed the consuming `[^!]` prefix to a zero-width `(?<!!)`
negative lookbehind, so adjacent links no longer compete for the same
delimiter character.

### 4. An escaped bracket in link/alt text breaks the match entirely

The id-capturing regexes use `[^\]]*` to capture label/alt text up to the
closing `]`. Text containing an escaped bracket — not uncommon in
scraped/OCR'd web content — stops the match at the first literal `]` it
sees (the one in `\]`), which isn't followed by `(`, so the whole match
attempt fails with no fallback.

**Fix:** changed the label/alt capture in all three regexes from
`[^\]]*` to `(?:\\.|[^\]])*`, so an escaped `\]` is treated as a literal
character instead of prematurely closing the group.

## Validation

Built from source (Qt6/CMake) and ran the patched importer's GUI against my
own real Joplin export multiple times, applying the fixes incrementally to
confirm each one addressed a distinct set of previously-missing resources.
Before this patch, roughly a third of resources were silently missing after
import; with all four fixes applied, essentially all of them import
successfully.

The only resource that didn't come through was a genuinely 0-byte file that
was already corrupted in my Joplin export before I ever touched QOwnNotes —
`Note::getInsertMediaMarkdown()` correctly declines to import a 0-byte
file, which is expected behavior, not something this patch changes.

## Repro data

I can't share my actual export (personal data), so I put together a small,
fully synthetic Joplin RAW export — no real data, 5 notes + 1 notebook, 7
resources, using genuinely valid/openable PDFs/PNGs/JPEG/HTML rather than
stub files — that reproduces all four issues independently. Attached as 
[repro-export-v2.zip](https://github.com/user-attachments/files/30622360/repro-export-v2.zip). Import it via "Import notes from Joplin" as usual;
on unpatched `main` some of the resources fail to import, and with this
patch all of them do. This is really the most important part of the PR
in case you want to solve these in different ways.
