### PR TITLE
docs: fix a split wget command and a dead nixpkgs link

### DIFF
--- a/webpage/src/faq/references.md
+++ b/webpage/src/faq/references.md
@@ -312,4 +312,4 @@ What other people said about QOwnNotes…
 
 - Alpine Linux: <https://pkgs.alpinelinux.org/packages?name=qownnotes&branch=edge>
 - nixos: <https://search.nixos.org/packages?query=qownnotes>
-  - <https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/office/qownnotes/default.nix>
+  - <https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/qo/qownnotes/package.nix>

--- a/webpage/src/installation/raspberry-pi-os.md
+++ b/webpage/src/installation/raspberry-pi-os.md
@@ -59,8 +59,7 @@ sudo apt-get install qownnotes
 Run the following shell commands to trust the repository.
 
 ```bash
-wget http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Raspbian_9.0/Release.key
--O - | sudo apt-key add -
+wget http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Raspbian_9.0/Release.key -O - | sudo apt-key add -
 ```
 
 Run the following shell commands to add the repository and install QOwnNotes from there.


### PR DESCRIPTION
Two small documentation fixes.

**Split `wget` command** — `webpage/src/installation/raspberry-pi-os.md`

The Raspbian 9.0 section has a stray newline in the middle of the command:

```bash
wget http://download.opensuse.org/repositories/home:/pbek:/QOwnNotes/Raspbian_9.0/Release.key
-O - | sudo apt-key add -
```

Running it verbatim: `wget` downloads `Release.key` into the working directory, then bash reports `-O: command not found`, so the key is never piped to `apt-key`. The user ends up with a stray file and an untrusted repository, with no obvious error.

The Raspbian 10, 11 and 12 sections in the same file all have it on one line — this one is a one-off. I confirmed the OBS `Raspbian_9.0` repository is still live (`Release.key` returns 200), so the section is worth keeping rather than removing.

**Dead nixpkgs link** — `webpage/src/faq/references.md`

nixpkgs moved to the by-name layout:

```
pkgs/applications/office/qownnotes/default.nix   404
pkgs/by-name/qo/qownnotes/package.nix            200
```

`lychee.toml` excludes both `github.com` and this file by path, so the link checker never sees it.

I only touched the English sources; `crowdin.yaml` maps `/webpage/src/faq/*.md` and `/webpage/src/installation/*.md` to the translated copies, so those regenerate from these.
