### PR TITLE
media: use the override suffix when finding an available file name

### DIFF
--- a/src/utils/misc.cpp
+++ b/src/utils/misc.cpp
@@ -2739,7 +2739,9 @@ QString Utils::Misc::findAvailableFileName(const QString &filePath, const QStrin
     const QFileInfo fileInfo(filePath);
     QString baseName = fileInfo.baseName();
     baseName.truncate(200);
-    const QString newSuffix = fileInfo.suffix();
+    // The path can be a temporary file without a correct suffix, so the caller may pass the
+    // suffix it detected from the mime type
+    const QString newSuffix = overrideSuffix.isEmpty() ? fileInfo.suffix() : overrideSuffix;
     QString newBaseName = baseName;
     QString newFileName = newBaseName;
 

--- a/tests/unit_tests/testcases/app/test_utilsmisc.cpp
+++ b/tests/unit_tests/testcases/app/test_utilsmisc.cpp
@@ -1,5 +1,7 @@
 #include "test_utilsmisc.h"
 
+#include <QFile>
+#include <QTemporaryDir>
 #include <QTest>
 
 #include "utils/listutils.h"
@@ -636,4 +638,30 @@ void TestUtilsMisc::testDetectFileFormatEdgeCases() {
 xdebug.remote_enable=1
 xdebug.remote_autostart=1)";
     QCOMPARE(detectFileFormat(ambiguousText), QString("ini"));
+}
+
+void TestUtilsMisc::testFindAvailableFileNameOverrideSuffix() {
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    // The override suffix must be used when the file path has no suffix at all,
+    // like a temporary file created from a QTemporaryFile template
+    QCOMPARE(findAvailableFileName(QStringLiteral("qownnotes-media-AbCdEf"), dir.path(),
+                                   QStringLiteral("png")),
+             QStringLiteral("qownnotes-media-AbCdEf.png"));
+
+    // The override suffix must also win over the suffix of the file path, because it is
+    // determined from the mime type of the file
+    QCOMPARE(findAvailableFileName(QStringLiteral("screenshot.jpeg"), dir.path(),
+                                   QStringLiteral("jpg")),
+             QStringLiteral("screenshot.jpg"));
+
+    // Without an override suffix the suffix of the file path is still used
+    QCOMPARE(findAvailableFileName(QStringLiteral("screenshot.jpeg"), dir.path()),
+             QStringLiteral("screenshot.jpeg"));
+
+    // A name that is already taken gets a counter appended, keeping the override suffix
+    QVERIFY(QFile(dir.filePath(QStringLiteral("image.png"))).open(QIODevice::WriteOnly));
+    QCOMPARE(findAvailableFileName(QStringLiteral("image"), dir.path(), QStringLiteral("png")),
+             QStringLiteral("image-1.png"));
 }

--- a/tests/unit_tests/testcases/app/test_utilsmisc.cpp
+++ b/tests/unit_tests/testcases/app/test_utilsmisc.cpp
@@ -652,9 +652,9 @@ void TestUtilsMisc::testFindAvailableFileNameOverrideSuffix() {
 
     // The override suffix must also win over the suffix of the file path, because it is
     // determined from the mime type of the file
-    QCOMPARE(findAvailableFileName(QStringLiteral("screenshot.jpeg"), dir.path(),
-                                   QStringLiteral("jpg")),
-             QStringLiteral("screenshot.jpg"));
+    QCOMPARE(
+        findAvailableFileName(QStringLiteral("screenshot.jpeg"), dir.path(), QStringLiteral("jpg")),
+        QStringLiteral("screenshot.jpg"));
 
     // Without an override suffix the suffix of the file path is still used
     QCOMPARE(findAvailableFileName(QStringLiteral("screenshot.jpeg"), dir.path()),

--- a/tests/unit_tests/testcases/app/test_utilsmisc.h
+++ b/tests/unit_tests/testcases/app/test_utilsmisc.h
@@ -40,6 +40,7 @@ class TestUtilsMisc : public QObject {
     void testDetectFileFormatSql();
     void testDetectFileFormatJavaScript();
     void testDetectFileFormatEdgeCases();
+    void testFindAvailableFileNameOverrideSuffix();
 };
 
 #endif    // TESTUTILSMISC_H


### PR DESCRIPTION
## Summary

`Utils::Misc::findAvailableFileName()` declares an `overrideSuffix` parameter (`misc.h:151`) but never reads it, so the returned name always keeps the suffix of the input path.

Both call sites in `src/entities/note.cpp` pass a suffix they detected from the file's mime type, precisely because the input is a temporary file whose name has no suffix or the wrong one. So pasted or imported media can be saved as `qownnotes-media-AbCdEf` with no extension, or keep a `.jpeg` the mime type says should be `.jpg`.

## Repro

```
before:
findAvailableFileName("qownnotes-media-AbCdEf", dir, "png") -> "qownnotes-media-AbCdEf"
findAvailableFileName("screenshot.jpeg", dir, "jpg")        -> "screenshot.jpeg"

after:
                                                            -> "qownnotes-media-AbCdEf.png"
                                                            -> "screenshot.jpg"
```

## The fix

Use `overrideSuffix` when it is not empty, otherwise the suffix of the path. This matches `makeFileNameRandom()`, which has the same parameter and already honours it.

## Verification

`testFindAvailableFileNameOverrideSuffix` covers the two cases above, the unchanged behaviour when no override is given, and the collision counter keeping the override (`image` plus an existing `image.png` gives `image-1.png`). Reverting `newSuffix` to `fileInfo.suffix()` fails it on the first comparison.

Full unit test target passes: 45, 3, 3, 5, 9, 2, 8 and 36 across the eight test classes, `[Tests PASS]`.

## Checklist

- [x] I read the code contribution guidelines
- [x] This is a small, self-contained fix
- [x] Created against `main`, from a separate branch
- [x] Followed the repository's commit message style
- [x] No translation files edited

*Written with AI assistance (Claude Code). I built the test target against Qt 5.15.2 and ran the suite and the mutation check myself.*
