### PR TITLE
Enhancement: preserve note modified date when importing from Joplin

### DIFF
--- a/src/dialogs/joplinimportdialog.cpp
+++ b/src/dialogs/joplinimportdialog.cpp
@@ -4,6 +4,7 @@
 #include <entities/notefolder.h>
 #include <entities/tag.h>
 
+#include <QDateTime>
 #include <QDebug>
 #include <QDir>
 #include <QFile>
@@ -365,7 +366,60 @@ bool JoplinImportDialog::importNote(const QString& id, const QString& text,
         note.storeNoteTextFileToDisk();
     }
 
+    // Joplin's raw export carries the note's real creation/modification
+    // history in its metadata block, but everything above this point wrote
+    // the note file "now", so file_last_modified would otherwise reflect
+    // the moment the import ran instead of the note's actual history
+    // (breaking Note -> Sort by -> By date). Restore the real timestamps as
+    // the last step, after every storeNoteTextFileToDisk() call above.
+    applyJoplinTimestamps(text, note);
+
     return true;
+}
+
+/**
+ * Applies a Joplin note's original updated_time metadata to the file
+ * already written to disk for that note, so the app's file_last_modified
+ * sorting reflects the note's real history instead of the moment the
+ * import ran.
+ *
+ * @param text the raw Joplin note text, still containing its metadata block
+ * @param note the already-stored, already-written-to-disk imported note
+ */
+void JoplinImportDialog::applyJoplinTimestamps(const QString& text, Note& note) {
+// QFile::setFileTime() was added in Qt 5.10; this project's floor is Qt 5.5,
+// so skip the correction gracefully on older Qt5 instead of failing to build.
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    auto match =
+        QRegularExpression("^updated_time: (.+)$", QRegularExpression::MultilineOption).match(text);
+
+    if (!match.hasMatch()) {
+        return;
+    }
+
+    // Joplin writes timestamps like "2019-11-15T16:16:34.302Z"
+    const QDateTime updatedTime =
+        QDateTime::fromString(match.captured(1).trimmed(), Qt::ISODateWithMs);
+
+    if (!updatedTime.isValid()) {
+        return;
+    }
+
+    // QFile::setFileTime silently fails unless the file is open
+    QFile noteFile(note.fullNoteFilePath());
+    if (noteFile.open(QIODevice::ReadWrite)) {
+        noteFile.setFileTime(updatedTime, QFileDevice::FileModificationTime);
+        noteFile.close();
+    }
+
+    // re-read the corrected mtime from disk into the note and persist it to
+    // the DB's file_last_modified column, which is what sort-by-date reads
+    note.updateNoteTextFromDisk();
+    note.store();
+#else
+    Q_UNUSED(text)
+    Q_UNUSED(note)
+#endif
 }
 
 int JoplinImportDialog::getImportCount() const { return _importCount; }

--- a/src/dialogs/joplinimportdialog.h
+++ b/src/dialogs/joplinimportdialog.h
@@ -44,6 +44,7 @@ class JoplinImportDialog : public MasterDialog {
     QHash<QString, NoteSubFolder> _importedFolders;
 
     bool importNote(const QString& id, const QString& text, const QString& dirPath);
+    static void applyJoplinTimestamps(const QString& text, Note& note);
     void tagNote(const QString& id, const Note& note);
     void handleImages(Note& note, const QString& dirPath);
     void handleAttachments(Note& note, const QString& dirPath);


### PR DESCRIPTION
Follow-up to #3672. The Joplin importer currently doesn't try to preserve
a note's real modified date — every imported note's `file_last_modified`
ends up as "whenever the import happened to write that file", so
`Note -> Sort by -> By date` (and search, which sorts the same list) can't
reflect a note's actual history after import. For a large imported
collection this mostly reads as random. This PR adds that, written with
Claude Code.

The change is small. `importNote()` already reads one field out of a note's
Joplin metadata block (`parent_id:`, for subfolder placement) via a regex
against the same `text` variable already in scope — this just adds a
second regex for `updated_time:` (Joplin's ISO-8601-with-milliseconds
timestamp, e.g. `2019-11-15T16:16:34.302Z`, which `QDateTime::fromString`
parses natively via `Qt::ISODateWithMs`), and applies it to the file with
`QFile::setFileTime()` as the very last step of the import, after all the
existing `storeNoteTextFileToDisk()` calls so nothing overwrites it
afterward. One thing worth flagging in review: `setFileTime()` only takes
effect if the file is open when it's called — easy to miss, since it fails
silently otherwise.

`setFileTime()` needs Qt 5.10+; the project floor is Qt 5.5, so the whole
block is behind a `QT_VERSION_CHECK` guard (same pattern already used
elsewhere in this codebase, e.g. `linkdialog.cpp`) — pre-5.10 Qt5 builds
just skip the correction and keep today's behavior, nothing breaks.

Scoped to modified time only. Creation time seemed worth attempting too at
first, but most POSIX filesystems (Linux included) don't expose a way to
set birth time after the fact via the calls Qt/the OS provide, so it'd be
dead code there — and modified time is what actually drives the sorting
that motivated this.

## Validation

Built and ran the enhanced importer's GUI against a synthetic repro export
(attached, 12 notes spanning 1998-2024). Currently, every imported note's
modified date collapses to the moment the import ran; with this change,
each one's file mtime (and the `file_last_modified` the app sorts by)
matches its real Joplin `updated_time`, confirmed down to correct
UTC-to-local conversion.

## Repro data

Small synthetic Joplin RAW export, no real data — 12 notes, each titled
like `Tag [2019-11-14] Doctor visit - lab results`, spanning 1998-2024.
The leading tag word is assigned in alphabetical order but in a note order
that's deliberately *not* chronological, so alphabetical-sort-order and
date-sort-order provably disagree — meaning correct sort order after import
demonstrates the change is reading each note's real date, not just
coincidentally reproducing title-string order. Attached as
`repro-timestamps.zip`. Import via "Import notes from Joplin"; currently,
`Note -> Sort by -> By date` comes out scrambled relative to the titles'
dates, and with this change it reads in correct chronological order.

[repro-timestamps.zip](https://github.com/user-attachments/files/31620846/repro-timestamps.zip)
