### PR TITLE
Fix notes with duplicate names in the same subfolder silently destroying each other's content

### DIFF
--- a/src/dialogs/joplinimportdialog.cpp
+++ b/src/dialogs/joplinimportdialog.cpp
@@ -10,6 +10,7 @@
 #include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QMessageBox>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
 
@@ -116,6 +117,7 @@ void JoplinImportDialog::on_importButton_clicked() {
     _attachmentData.clear();
     _folderData.clear();
     _importedFolders.clear();
+    _importedAttachmentFileNames.clear();
 
     auto directoryName = ui->directoryLineEdit->text();
     QDir dir(directoryName);
@@ -123,6 +125,19 @@ void JoplinImportDialog::on_importButton_clicked() {
     if (directoryName.isEmpty() || !dir.exists()) {
         return;
     }
+
+    // A Joplin resource referenced by more than one image tag (e.g. the same
+    // picture used twice) would otherwise pop up a "use existing file?"
+    // dialog once per repeat, or -- unanswered -- fall back to writing a
+    // byte-identical "<id>-1.ext" duplicate (see
+    // Note::getInsertMediaMarkdown()). Force it to reuse the existing file
+    // for the duration of this import, then restore whatever the user had
+    // configured.
+    SettingsService importSettings;
+    const QString reuseImageOverrideKey =
+        QStringLiteral("MessageBoxOverride/insert-media-use-existing-image");
+    const QVariant previousReuseImageOverride = importSettings.value(reuseImageOverrideKey);
+    importSettings.setValue(reuseImageOverrideKey, QMessageBox::Yes);
 
     QStringList files = dir.entryList(QStringList() << "*.md", QDir::Files);
     _dirPath = dir.path();
@@ -216,6 +231,12 @@ void JoplinImportDialog::on_importButton_clicked() {
     }
 
     ui->importButton->setEnabled(true);
+
+    if (previousReuseImageOverride.isValid()) {
+        importSettings.setValue(reuseImageOverrideKey, previousReuseImageOverride);
+    } else {
+        importSettings.remove(reuseImageOverrideKey);
+    }
 }
 
 bool JoplinImportDialog::importFolders() {
@@ -644,15 +665,46 @@ void JoplinImportDialog::handleAttachments(Note& note, const QString& dirPath) {
         qDebug() << __func__ << " - 'attachmentName': " << attachmentName;
         qDebug() << __func__ << " - 'attachmentId': " << attachmentId;
 
-        auto* mediaFile = findResourceFile(dirPath, attachmentId, attachmentData);
+        QString mediaMarkdown;
 
-        qDebug() << __func__ << " - 'mediaFile': " << mediaFile;
+        // This resource was already copied into the attachments folder
+        // earlier in this import (the same resource referenced more than
+        // once, e.g. linked twice in one note, or shared across notes) --
+        // reuse that copy instead of writing another byte-identical
+        // "<id>-1.ext" duplicate.
+        const auto existingFileNameIt = _importedAttachmentFileNames.constFind(attachmentId);
+        if (existingFileNameIt != _importedAttachmentFileNames.constEnd()) {
+            const QString title = attachmentName.isEmpty() ? *existingFileNameIt : attachmentName;
+            mediaMarkdown = QStringLiteral("[") + title + QStringLiteral("](") +
+                            note.attachmentUrlStringForFileName(*existingFileNameIt) +
+                            QStringLiteral(")");
+        } else {
+            auto* mediaFile = findResourceFile(dirPath, attachmentId, attachmentData);
 
-        if (mediaFile == nullptr) {
-            continue;
+            qDebug() << __func__ << " - 'mediaFile': " << mediaFile;
+
+            if (mediaFile == nullptr) {
+                continue;
+            }
+
+            // The destination filename getInsertAttachmentMarkdown() is
+            // about to use is derived from mediaFile's own (source) file
+            // name, which findResourceFile() always sets to "<id>.<ext>" --
+            // unique per resource id, so no other note/resource can already
+            // occupy it. Capturing it here (rather than parsing it back out
+            // of the returned Markdown) is exact and avoids re-deriving
+            // Note's URL-encoding/collision-suffix logic independently.
+            const QString destinationFileName = QFileInfo(mediaFile->fileName()).fileName();
+
+            mediaMarkdown = note.getInsertAttachmentMarkdown(mediaFile, attachmentName);
+
+            // getInsertAttachmentMarkdown() silently no-ops (empty return)
+            // for a zero-byte resource, in which case nothing was actually
+            // copied -- don't cache a filename that was never written.
+            if (!mediaMarkdown.isEmpty()) {
+                _importedAttachmentFileNames.insert(attachmentId, destinationFileName);
+            }
         }
-
-        QString mediaMarkdown = note.getInsertAttachmentMarkdown(mediaFile, attachmentName);
 
         qDebug() << __func__ << " - 'mediaMarkdown': " << mediaMarkdown;
         noteText.replace(attachmentTag, mediaMarkdown);

--- a/src/dialogs/joplinimportdialog.h
+++ b/src/dialogs/joplinimportdialog.h
@@ -42,6 +42,12 @@ class JoplinImportDialog : public MasterDialog {
     QHash<QString, QString> _imageData;
     QHash<QString, QString> _attachmentData;
     QHash<QString, NoteSubFolder> _importedFolders;
+    // Resource id -> attachments-folder filename already written for it this
+    // import run, so a resource referenced more than once (e.g. once as an
+    // inline attachment link and again elsewhere in the same or a later
+    // note) reuses the existing copy instead of writing another
+    // byte-identical "<id>-1.ext" duplicate.
+    QHash<QString, QString> _importedAttachmentFileNames;
 
     bool importNote(const QString& id, const QString& text, const QString& dirPath);
     static void applyJoplinTimestamps(const QString& text, Note& note);

--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -1016,14 +1016,14 @@ Note Note::fetchByName(const QRegularExpression &regExp, int noteSubFolderId) {
     return Note();
 }
 
-Note Note::fetchByFileName(const QString &fileName, int noteSubFolderId) {
+Note Note::fetchByFileName(const QString &fileName, int noteSubFolderId, int excludeNoteId) {
     Note note;
     // get the active note subfolder id if none was set
     if (noteSubFolderId == -1) {
         noteSubFolderId = NoteSubFolder::activeNoteSubFolderId();
     }
 
-    note.fillByFileName(fileName, noteSubFolderId);
+    note.fillByFileName(fileName, noteSubFolderId, excludeNoteId);
     return note;
 }
 
@@ -1032,7 +1032,7 @@ Note Note::fetchByFileName(const QString &fileName, const QString &noteSubFolder
     return fetchByFileName(fileName, noteSubFolder.getId());
 }
 
-bool Note::fillByFileName(const QString &fileName, int noteSubFolderId) {
+bool Note::fillByFileName(const QString &fileName, int noteSubFolderId, int excludeNoteId) {
     const QSqlDatabase db = QSqlDatabase::database(QStringLiteral("memory"));
     QSqlQuery query(db);
 
@@ -1041,11 +1041,25 @@ bool Note::fillByFileName(const QString &fileName, int noteSubFolderId) {
         noteSubFolderId = NoteSubFolder::activeNoteSubFolderId();
     }
 
-    query.prepare(
-        QStringLiteral("SELECT * FROM note WHERE file_name = :file_name AND "
-                       "note_sub_folder_id = :note_sub_folder_id"));
+    // Excluding by id directly in the query (rather than fetching and
+    // checking the id afterwards) matters for databases already affected by
+    // the duplicate-name bug this is guarding against: with duplicate rows
+    // for the same (file_name, note_sub_folder_id) already present, SQLite's
+    // row order without ORDER BY is unspecified, so a post-fetch self-check
+    // could land on the caller's own row first and miss the other duplicate
+    // entirely.
+    QString queryString = QStringLiteral(
+        "SELECT * FROM note WHERE file_name = :file_name AND "
+        "note_sub_folder_id = :note_sub_folder_id");
+    if (excludeNoteId > 0) {
+        queryString += QStringLiteral(" AND id != :exclude_note_id");
+    }
+    query.prepare(queryString);
     query.bindValue(QStringLiteral(":file_name"), fileName);
     query.bindValue(QStringLiteral(":note_sub_folder_id"), noteSubFolderId);
+    if (excludeNoteId > 0) {
+        query.bindValue(QStringLiteral(":exclude_note_id"), excludeNoteId);
+    }
 
     if (!query.exec()) {
         qWarning() << __func__ << ": " << query.lastError();
@@ -2959,10 +2973,17 @@ bool Note::handleNoteTextFileName() {
             // otherwise find its own row at that candidate and treat it as
             // a collision with itself, escalating to "Title 2", "Title 3",
             // ... on every subsequent call instead of keeping its name.
+            //
+            // The exclusion is done inside the query itself (fetchByFileName's
+            // excludeNoteId) rather than via a post-fetch id check, so that a
+            // database already holding duplicate rows for this filename --
+            // the exact state this loop is meant to clean up -- still turns
+            // up the *other* row instead of matching this note's own first.
+            const int excludeNoteId = this->_id > 0 ? this->_id : -1;
             while (true) {
-                const Note existingNote = Note::fetchByFileName(fileName, this->_noteSubFolderId);
-                if (!existingNote.isFetched() ||
-                    (this->_id > 0 && existingNote.getId() == this->_id)) {
+                const Note existingNote =
+                    Note::fetchByFileName(fileName, this->_noteSubFolderId, excludeNoteId);
+                if (!existingNote.isFetched()) {
                     break;
                 }
 
@@ -3036,13 +3057,12 @@ bool Note::canWriteToNoteFile() {
     const bool fileExistedBefore = QFile::exists(path);
 
     QFile file(path);
-    // Deliberately QIODevice::ReadWrite, not WriteOnly: for QFile, WriteOnly
-    // implies Truncate unless combined with Append, so opening an *existing*
-    // file here to merely probe writability was silently discarding its
-    // content as a side effect. ReadWrite still creates a missing file (so
-    // the writability check is unchanged) without truncating one that's
-    // already there.
-    const bool canWrite = file.open(QIODevice::ReadWrite);
+    // WriteOnly | Append probes writability without truncating: WriteOnly
+    // alone implies Truncate, but combining it with Append suppresses that,
+    // same as ReadWrite would. Unlike ReadWrite though, this doesn't also
+    // require read permission on the file, so it won't misreport a
+    // write-only-permissioned file as unwritable.
+    const bool canWrite = file.open(QIODevice::WriteOnly | QIODevice::Append);
 
     if (file.isOpen()) {
         file.close();

--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -2936,8 +2936,36 @@ bool Note::handleNoteTextFileName() {
             int nameCount = 0;
             const QString nameBase = name;
 
-            // check if note with this filename already exists
-            while (Note::fetchByFileName(fileName).isFetched()) {
+            // Check if a *different* note with this filename already exists
+            // in the subfolder this note is actually being stored in.
+            //
+            // Without the explicit subfolder id, fetchByFileName() falls
+            // back to whatever subfolder happens to be active in the UI,
+            // which is frequently not this note's own subfolder (e.g.
+            // during a Joplin/Evernote import into a specific target
+            // subfolder) -- that let two notes with an identical title
+            // inside the same target subfolder collide undetected, silently
+            // overwriting one another on disk.
+            //
+            // Excluding this note's own id matters because
+            // handleNoteTextFileName() is called again for every note from
+            // storeNoteTextFileToDisk() (up to a few times per note during
+            // import, as image/attachment handling re-save the note text).
+            // The note's *text* never has its title line rewritten with the
+            // chosen suffix (see the comment below), so "name" recomputed
+            // from the text keeps not matching the already-suffixed
+            // "_name" on every later call, re-entering this loop. Once this
+            // note has stored itself once under, say, "Title 1", it would
+            // otherwise find its own row at that candidate and treat it as
+            // a collision with itself, escalating to "Title 2", "Title 3",
+            // ... on every subsequent call instead of keeping its name.
+            while (true) {
+                const Note existingNote = Note::fetchByFileName(fileName, this->_noteSubFolderId);
+                if (!existingNote.isFetched() ||
+                    (this->_id > 0 && existingNote.getId() == this->_id)) {
+                    break;
+                }
+
                 // find new filename for the note
                 name = nameBase + QStringLiteral(" ") + QString::number(++nameCount);
                 fileName = generateNoteFileNameFromName(name);
@@ -3001,14 +3029,25 @@ void Note::generateFileNameFromName() { _fileName = generateNoteFileNameFromName
  * @return
  */
 bool Note::canWriteToNoteFile() {
-    QFile file(fullNoteFilePath());
-    const bool canWrite = file.open(QIODevice::WriteOnly);
-    const bool fileExists = file.exists();
+    const QString path = fullNoteFilePath();
+    // Capture existence *before* opening -- opening below can itself create
+    // the file, which would make a post-open check always see it as
+    // "already there".
+    const bool fileExistedBefore = QFile::exists(path);
+
+    QFile file(path);
+    // Deliberately QIODevice::ReadWrite, not WriteOnly: for QFile, WriteOnly
+    // implies Truncate unless combined with Append, so opening an *existing*
+    // file here to merely probe writability was silently discarding its
+    // content as a side effect. ReadWrite still creates a missing file (so
+    // the writability check is unchanged) without truncating one that's
+    // already there.
+    const bool canWrite = file.open(QIODevice::ReadWrite);
 
     if (file.isOpen()) {
         file.close();
 
-        if (!fileExists) {
+        if (!fileExistedBefore) {
             file.remove();
         }
     }
@@ -3654,8 +3693,17 @@ bool Note::renameNoteFile(QString newName) {
         return false;
     }
 
-    // check if name already exists
-    const Note existingNote = Note::fetchByName(newName);
+    // Check if a *different* note with this name already exists in the
+    // subfolder this note actually lives in. Same wrong-scope pattern as
+    // handleNoteTextFileName(): without the explicit subfolder id,
+    // fetchByName() falls back to whatever subfolder happens to be active
+    // in the UI, not this note's own -- a false negative here lets
+    // _fileName/_name/store() below run for a name that DOES already exist
+    // in this note's subfolder, and only the final file.rename() call
+    // (which safely refuses when the destination exists) stops the rename
+    // from actually happening -- but by then the DB row has already been
+    // updated to a file_name that doesn't match what's on disk.
+    const Note existingNote = Note::fetchByName(newName, this->_noteSubFolderId);
     if (existingNote.isFetched() && (existingNote.getId() != _id)) {
         return false;
     }

--- a/src/entities/note.h
+++ b/src/entities/note.h
@@ -97,7 +97,8 @@ class Note {
 
     static Note fetchByName(const QRegularExpression &regExp, int noteSubFolderId = -1);
 
-    static Note fetchByFileName(const QString &fileName, int noteSubFolderId = -1);
+    static Note fetchByFileName(const QString &fileName, int noteSubFolderId = -1,
+                                int excludeNoteId = -1);
 
     static Note fetchByFileName(const QString &fileName, const QString &noteSubFolderPathData);
 
@@ -184,7 +185,7 @@ class Note {
 
     Note fillFromQuery(const QSqlQuery &query);
 
-    bool fillByFileName(const QString &fileName, int noteSubFolderId = -1);
+    bool fillByFileName(const QString &fileName, int noteSubFolderId = -1, int excludeNoteId = -1);
 
     bool removeNoteFile();
 

--- a/tests/unit_tests/testcases/app/test_notes.cpp
+++ b/tests/unit_tests/testcases/app/test_notes.cpp
@@ -25,6 +25,10 @@
 #include <QRandomGenerator>
 #endif
 
+#ifdef Q_OS_UNIX
+#include <unistd.h>
+#endif
+
 #include "helpers/codetohtmlconverter.h"
 #include "services/databaseservice.h"
 
@@ -1669,6 +1673,113 @@ void TestNotes::testEditingExistingNoteTitleToMatchAnotherNoteDestroysItsContent
     QVERIFY2(victimFileAfterEdit.size() > 0,
              "editing an unrelated note's title to collide with the victim, with no import and "
              "no dedicated rename action involved, must not destroy the victim's content");
+}
+
+/**
+ * Direct regression test for the excludeNoteId parameter added to
+ * Note::fetchByFileName()/fillByFileName(), per pbek's review comment on this
+ * PR: without it, the collision-avoidance loop excluded "myself" only *after*
+ * fetching a single row -- SQLite gives no ordering guarantee without ORDER
+ * BY -- so on a database that already has two rows sharing the same
+ * (file_name, note_sub_folder_id) from before this fix existed, there was a
+ * real chance the query would hand back the calling note's own row, get
+ * waved through by the self-id check, and never surface the genuine
+ * remaining duplicate at all.
+ *
+ * This constructs that already-corrupted state directly (two notes stored
+ * with an identical file_name in the same subfolder, via the raw store()
+ * used to seed test data rather than the app's own collision-avoidance path)
+ * and asserts the new parameter deterministically finds the *other* row,
+ * regardless of which of the two ids is excluded.
+ */
+void TestNotes::testFetchByFileNameExcludesGivenNoteIdAmongDuplicates() {
+    NoteSubFolder targetFolder =
+        createTestNoteSubFolder(uniqueTestName(QStringLiteral("corrupted-notebook")));
+
+    const QString sharedName = uniqueTestName(QStringLiteral("Shared"));
+    const QString sharedFileName = sharedName + QStringLiteral(".md");
+
+    Note noteX;
+    noteX.setNoteSubFolder(targetFolder);
+    noteX.setName(sharedName);
+    QVERIFY(noteX.store());
+    QCOMPARE(noteX.getFileName(), sharedFileName);
+
+    Note noteY;
+    noteY.setNoteSubFolder(targetFolder);
+    noteY.setName(sharedName);
+    QVERIFY(noteY.store());
+    QCOMPARE(noteY.getFileName(), sharedFileName);
+
+    QVERIFY(noteX.getId() != noteY.getId());
+
+    const Note foundExcludingX =
+        Note::fetchByFileName(sharedFileName, targetFolder.getId(), noteX.getId());
+    QVERIFY2(foundExcludingX.isFetched(),
+             "excluding note X must still surface note Y's duplicate row");
+    QCOMPARE(foundExcludingX.getId(), noteY.getId());
+
+    const Note foundExcludingY =
+        Note::fetchByFileName(sharedFileName, targetFolder.getId(), noteY.getId());
+    QVERIFY2(foundExcludingY.isFetched(),
+             "excluding note Y must still surface note X's duplicate row");
+    QCOMPARE(foundExcludingY.getId(), noteX.getId());
+}
+
+/**
+ * Direct regression test for canWriteToNoteFile()'s writability probe, per
+ * pbek's review comment on this PR: opening with QIODevice::ReadWrite (the
+ * fix in place before this test was added) requires read permission in
+ * addition to write permission, so it misreported "can't write" for a file
+ * that has write permission but not read permission -- something an actual
+ * write (opened WriteOnly, which needs no read access) would have handled
+ * fine. QIODevice::WriteOnly | QIODevice::Append avoids that false negative
+ * while still not truncating, unlike bare WriteOnly (the original bug this
+ * whole PR exists to close).
+ */
+void TestNotes::testCanWriteToNoteFileSucceedsWithoutReadPermission() {
+#ifdef Q_OS_UNIX
+    if (::geteuid() == 0) {
+        QSKIP("running as root -- file permission bits aren't enforced, test is meaningless");
+    }
+
+    const QString title = uniqueTestName(QStringLiteral("Write Only Permissions"));
+    Note note;
+    note.setNoteText(QStringLiteral("# %1\n\nOriginal content\n").arg(title));
+    QVERIFY(note.handleNoteTextFileName());
+    QVERIFY(note.store());
+    QVERIFY(note.storeNoteTextFileToDisk());
+
+    const QString path = note.fullNoteFilePath();
+    QVERIFY(QFile::exists(path));
+
+    QByteArray originalContent;
+    {
+        QFile file(path);
+        QVERIFY(file.open(QIODevice::ReadOnly));
+        originalContent = file.readAll();
+    }
+    QVERIFY(!originalContent.isEmpty());
+
+    // Write-only, no read permission for anyone -- an unusual but valid state
+    // (e.g. after a restrictive umask or an external sync tool).
+    QVERIFY(QFile::setPermissions(path, QFileDevice::WriteOwner));
+
+    QVERIFY2(note.canWriteToNoteFile(),
+             "a write-only-permissioned file is still writable and must not be misreported as "
+             "unwritable");
+
+    // Restore read permission so the test itself can verify the content --
+    // the probe must never have truncated the file as a side effect.
+    QVERIFY(QFile::setPermissions(path, QFileDevice::ReadOwner | QFileDevice::WriteOwner));
+
+    QFile fileAfter(path);
+    QVERIFY(fileAfter.open(QIODevice::ReadOnly));
+    QCOMPARE(fileAfter.readAll(), originalContent);
+    fileAfter.close();
+#else
+    QSKIP("POSIX permission bits test only applies on unix-like platforms");
+#endif
 }
 
 // QTEST_MAIN(TestNotes)

--- a/tests/unit_tests/testcases/app/test_notes.cpp
+++ b/tests/unit_tests/testcases/app/test_notes.cpp
@@ -17,6 +17,7 @@
 #include "entities/bookmark.h"
 #include "entities/commandsnippet.h"
 #include "entities/notesubfolder.h"
+#include "entities/trashitem.h"
 #include "services/settingsservice.h"
 #include "utils/urlhandler.h"
 
@@ -1419,6 +1420,255 @@ void TestNotes::testCommandSnippetsKeepNearestHeadingForCodeBlocks() {
              QStringLiteral("aktuelles Datum"));
     QCOMPARE(whoSnippet.value(QStringLiteral("description")).toString(), QStringLiteral("Wer?"));
     QCOMPARE(lsSnippet.value(QStringLiteral("description")).toString(), QStringLiteral("Test 2b"));
+}
+
+/**
+ * Duplicate-title-collision fix, found via Joplin-import validation but not
+ * import-specific: it affects any note creation/rename in the app.
+ *
+ * Before the fix, Note::handleNoteTextFileName()'s duplicate-avoidance loop
+ * called Note::fetchByFileName(fileName) with no explicit subfolder, which
+ * resolved to NoteSubFolder::activeNoteSubFolderId() -- the UI's currently
+ * active subfolder, not the subfolder the note is actually being written
+ * into. Combined with canWriteToNoteFile() probing writability by opening
+ * QIODevice::WriteOnly (which truncates an existing file), two notes with an
+ * identical title landing in the same *non-active* subfolder (e.g. a Joplin
+ * notebook import) would silently destroy one another's content instead of
+ * the second being suffixed away from the collision.
+ *
+ * This reproduces the exact sequence JoplinImportDialog::importNote()
+ * performs and asserts the *fixed* (correct) outcome: note B gets suffixed,
+ * note A's file and content are left untouched.
+ */
+void TestNotes::testDuplicateTitleInNonActiveSubfolderGetsSuffixedNotOverwritten() {
+    // The trashItem table lives in the per-note-folder database, which
+    // initTestCase() never sets up (only the "memory" note/tag/subfolder
+    // tables); the real app does this at startup (see
+    // NoteIndexManager::buildNotesIndex(), noteindexmanager.cpp:354-355).
+    DatabaseService::createNoteFolderConnection();
+    DatabaseService::setupNoteFolderTables();
+
+    NoteSubFolder targetFolder =
+        createTestNoteSubFolder(uniqueTestName(QStringLiteral("joplin-notebook")));
+
+    // Sanity check on the premise: the folder notes are being imported into
+    // is not the UI's "active" subfolder, exactly as during a real import.
+    QVERIFY(NoteSubFolder::activeNoteSubFolderId() != targetFolder.getId());
+
+    const QString title = uniqueTestName(QStringLiteral("Duplicate Title"));
+
+    // --- Note A: imported first, writes cleanly ---
+    Note noteA;
+    noteA.setNoteSubFolder(targetFolder);
+    noteA.setNoteText(QStringLiteral("# %1\n\nContent A\n").arg(title));
+    QVERIFY(noteA.handleNoteTextFileName());
+    QVERIFY(noteA.store());
+    QVERIFY(noteA.storeNoteTextFileToDisk());
+
+    const QString noteAFileName = noteA.getFileName();
+    const QString noteAFilePath = noteA.fullNoteFilePath();
+    QVERIFY2(QFile::exists(noteAFilePath), "note A's file should exist after its own write");
+    const qint64 noteAOriginalSize = QFileInfo(noteAFilePath).size();
+    QVERIFY(noteAOriginalSize > 0);
+
+    // --- Note B: same title, same target subfolder ---
+    Note noteB;
+    noteB.setNoteSubFolder(targetFolder);
+    noteB.setNoteText(QStringLiteral("# %1\n\nContent B\n").arg(title));
+
+    // FIXED: the collision-avoidance loop now scopes the check to this
+    // note's own target subfolder, so it correctly finds note A and
+    // suffixes note B's name away from the collision.
+    QVERIFY(noteB.handleNoteTextFileName());
+    QVERIFY2(noteB.getFileName() != noteAFileName,
+             "note B should be suffixed away from note A's colliding name");
+
+    // FIXED: canWriteToNoteFile()'s writability probe no longer truncates
+    // note A's file as a side effect (it isn't even the same file anymore,
+    // but assert the content survived regardless).
+    QFile fileAAfterCollisionCheck(noteAFilePath);
+    QVERIFY(fileAAfterCollisionCheck.exists());
+    QCOMPARE(fileAAfterCollisionCheck.size(), noteAOriginalSize);
+
+    QVERIFY(noteB.store());
+    QVERIFY(noteB.storeNoteTextFileToDisk());
+
+    // Both notes now have their own distinct file, each with its own
+    // content intact.
+    QFile fileA(noteAFilePath);
+    QVERIFY(fileA.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString contentsA = QString::fromUtf8(fileA.readAll());
+    fileA.close();
+    QVERIFY(contentsA.contains(QStringLiteral("Content A")));
+    QVERIFY(!contentsA.contains(QStringLiteral("Content B")));
+
+    QFile fileB(noteB.fullNoteFilePath());
+    QVERIFY(fileB.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString contentsB = QString::fromUtf8(fileB.readAll());
+    fileB.close();
+    QVERIFY(contentsB.contains(QStringLiteral("Content B")));
+    QVERIFY(!contentsB.contains(QStringLiteral("Content A")));
+
+    // Two independent, non-colliding DB rows, correctly scoped to the same
+    // subfolder but with distinct file names.
+    const Note refetchedA = Note::fetch(noteA.getId());
+    const Note refetchedB = Note::fetch(noteB.getId());
+    QVERIFY(refetchedA.isFetched());
+    QVERIFY(refetchedB.isFetched());
+    QVERIFY(refetchedA.getFileName() != refetchedB.getFileName());
+    QCOMPARE(refetchedA.getNoteSubFolderId(), refetchedB.getNoteSubFolderId());
+
+    // No trash entry was needed -- there was no collision left to clean up.
+    QCOMPARE(TrashItem::countAll(), 0);
+}
+
+/**
+ * Regression check for the fix above: the far more common case (two notes
+ * with an identical title created directly in the currently *active*
+ * subfolder, e.g. plain in-app note creation, no import involved) must keep
+ * working exactly as before -- the second note still gets suffixed.
+ */
+void TestNotes::testDuplicateTitleInActiveSubfolderStillGetsSuffixed() {
+    QVERIFY(NoteSubFolder::activeNoteSubFolderId() == 0);
+
+    const QString title = uniqueTestName(QStringLiteral("Active Folder Duplicate"));
+
+    Note noteA;
+    noteA.setNoteText(QStringLiteral("# %1\n\nContent A\n").arg(title));
+    QVERIFY(noteA.handleNoteTextFileName());
+    QVERIFY(noteA.store());
+    QVERIFY(noteA.storeNoteTextFileToDisk());
+
+    Note noteB;
+    noteB.setNoteText(QStringLiteral("# %1\n\nContent B\n").arg(title));
+    QVERIFY(noteB.handleNoteTextFileName());
+
+    QVERIFY2(noteB.getFileName() != noteA.getFileName(),
+             "duplicate titles in the active subfolder must still be suffixed apart");
+    QVERIFY(noteB.getName().startsWith(title));
+}
+
+/**
+ * Answers a direct question: can the duplicate-title bug's *sibling*
+ * manifest outside of import, via the app's ordinary "Rename note" action
+ * (or the scripting API's rename)? Note::renameNoteFile() has the exact same
+ * unscoped Note::fetchByName(newName) pattern (note.cpp ~3697), resolving to
+ * NoteSubFolder::activeNoteSubFolderId() rather than this note's own
+ * subfolder.
+ *
+ * Unlike handleNoteTextFileName()'s canWriteToNoteFile() probe, this does
+ * NOT destroy the other note's content: renameNoteFile()'s final step is
+ * QFile::rename(), and direct testing confirms Qt's QFile::rename() safely
+ * *refuses* when the destination already exists (returns false, error
+ * "Destination file exists", touching neither file). So the practical bug
+ * here is narrower than data loss: before the fix, the wrong-scope check
+ * produces a false negative, letting _fileName/_name/store() run for a name
+ * that DOES already exist in this note's actual subfolder -- only the final
+ * file.rename() call stops the operation, by which point the DB row would
+ * already claim a file_name that the rename never actually produced on
+ * disk. The fix makes the existence check correct up front, so the whole
+ * rename is refused cleanly, before anything is mutated.
+ */
+void TestNotes::testRenameNoteFileToExistingNameInNonActiveSubfolder() {
+    NoteSubFolder targetFolder =
+        createTestNoteSubFolder(uniqueTestName(QStringLiteral("some-notebook")));
+    QVERIFY(NoteSubFolder::activeNoteSubFolderId() != targetFolder.getId());
+
+    const QString existingName = uniqueTestName(QStringLiteral("Existing Note"));
+    Note noteA;
+    noteA.setNoteSubFolder(targetFolder);
+    noteA.setNoteText(
+        QStringLiteral("# %1\n\nOriginal content, not involved in any rename\n").arg(existingName));
+    QVERIFY(noteA.handleNoteTextFileName());
+    QVERIFY(noteA.store());
+    QVERIFY(noteA.storeNoteTextFileToDisk());
+
+    const QString noteAFilePath = noteA.fullNoteFilePath();
+    QVERIFY(QFile::exists(noteAFilePath));
+
+    const QString otherName = uniqueTestName(QStringLiteral("Some Other Note"));
+    Note noteB;
+    noteB.setNoteSubFolder(targetFolder);
+    noteB.setNoteText(QStringLiteral("# %1\n\nAbout to be renamed\n").arg(otherName));
+    QVERIFY(noteB.handleNoteTextFileName());
+    QVERIFY(noteB.store());
+    QVERIFY(noteB.storeNoteTextFileToDisk());
+    const QString noteBFileNameBefore = noteB.getFileName();
+    const QString noteBFilePath = noteB.fullNoteFilePath();
+
+    // FIXED: correctly detects the real collision in note B's own subfolder
+    // and refuses the rename outright, before mutating anything.
+    QVERIFY2(!noteB.renameNoteFile(existingName),
+             "renaming onto an existing note's name in the same subfolder must be refused");
+
+    // Nothing was mutated by the refused attempt: note B still has its own
+    // original name/file, note A's file is completely untouched.
+    QCOMPARE(noteB.getFileName(), noteBFileNameBefore);
+    QVERIFY(QFile::exists(noteBFilePath));
+
+    QFile fileA(noteAFilePath);
+    QVERIFY(fileA.open(QIODevice::ReadOnly | QIODevice::Text));
+    const QString contentsA = QString::fromUtf8(fileA.readAll());
+    fileA.close();
+    QVERIFY(contentsA.contains(QStringLiteral("Original content")));
+}
+
+/**
+ * The far more common real-world trigger than Note::renameNoteFile(): since
+ * QOwnNotes derives a note's name from the first line of its own Markdown
+ * text, simply editing an EXISTING note's title (in the normal editor, no
+ * dedicated "Rename" action, no import) to match another existing note's
+ * title in the same *non-active* subfolder goes through
+ * storeNoteTextFileToDisk() -> handleNoteTextFileName() ->
+ * canWriteToNoteFile() -- the exact same truncate-as-a-side-effect path
+ * traced for Joplin import. Unlike renameNoteFile()'s QFile::rename() (which
+ * safely refuses when the destination already exists, per direct testing:
+ * QFile::rename returns false with "Destination file exists" and touches
+ * neither file), canWriteToNoteFile() opens the colliding path directly with
+ * QIODevice::WriteOnly, which has no such existence check and destroys the
+ * target's content before any rename is even attempted.
+ */
+void TestNotes::testEditingExistingNoteTitleToMatchAnotherNoteDestroysItsContent() {
+    NoteSubFolder targetFolder =
+        createTestNoteSubFolder(uniqueTestName(QStringLiteral("another-notebook")));
+    QVERIFY(NoteSubFolder::activeNoteSubFolderId() != targetFolder.getId());
+
+    const QString victimTitle = uniqueTestName(QStringLiteral("Victim Note"));
+    Note victim;
+    victim.setNoteSubFolder(targetFolder);
+    victim.setNoteText(
+        QStringLiteral("# %1\n\nImportant content nobody is touching\n").arg(victimTitle));
+    QVERIFY(victim.handleNoteTextFileName());
+    QVERIFY(victim.store());
+    QVERIFY(victim.storeNoteTextFileToDisk());
+
+    const QString victimFilePath = victim.fullNoteFilePath();
+    QVERIFY(QFile::exists(victimFilePath));
+    QVERIFY(QFileInfo(victimFilePath).size() > 0);
+
+    // A second, pre-existing note in the same subfolder, being edited by the
+    // user -- nothing to do with the victim, no import, no dedicated rename
+    // action. The user just retitles it (e.g. a typo fix, or copy-pasting a
+    // heading) to something that happens to already exist in this notebook.
+    const QString editedTitle = uniqueTestName(QStringLiteral("Being Edited"));
+    Note edited;
+    edited.setNoteSubFolder(targetFolder);
+    edited.setNoteText(QStringLiteral("# %1\n\nOriginal text before the edit\n").arg(editedTitle));
+    QVERIFY(edited.handleNoteTextFileName());
+    QVERIFY(edited.store());
+    QVERIFY(edited.storeNoteTextFileToDisk());
+
+    // The user edits the first line of "edited" to the victim's title and
+    // saves -- ordinary editing, the app's normal live-save path.
+    edited.setNoteText(QStringLiteral("# %1\n\nText after the retitle\n").arg(victimTitle));
+    bool currentNoteTextChanged = false;
+    edited.storeNoteTextFileToDisk(currentNoteTextChanged);
+
+    QFile victimFileAfterEdit(victimFilePath);
+    QVERIFY2(victimFileAfterEdit.exists(), "the victim note's file should still be present");
+    QVERIFY2(victimFileAfterEdit.size() > 0,
+             "editing an unrelated note's title to collide with the victim, with no import and "
+             "no dedicated rename action involved, must not destroy the victim's content");
 }
 
 // QTEST_MAIN(TestNotes)

--- a/tests/unit_tests/testcases/app/test_notes.h
+++ b/tests/unit_tests/testcases/app/test_notes.h
@@ -90,6 +90,13 @@ class TestNotes : public QObject {
 
     /* Command snippet parsing tests */
     void testCommandSnippetsKeepNearestHeadingForCodeBlocks();
+
+    /* Duplicate-title-collision fix (found via Joplin-import validation, not
+     * import-specific -- affects any note creation/rename) */
+    void testDuplicateTitleInNonActiveSubfolderGetsSuffixedNotOverwritten();
+    void testDuplicateTitleInActiveSubfolderStillGetsSuffixed();
+    void testRenameNoteFileToExistingNameInNonActiveSubfolder();
+    void testEditingExistingNoteTitleToMatchAnotherNoteDestroysItsContent();
 };
 
 #endif    // TESTNOTES_H

--- a/tests/unit_tests/testcases/app/test_notes.h
+++ b/tests/unit_tests/testcases/app/test_notes.h
@@ -97,6 +97,10 @@ class TestNotes : public QObject {
     void testDuplicateTitleInActiveSubfolderStillGetsSuffixed();
     void testRenameNoteFileToExistingNameInNonActiveSubfolder();
     void testEditingExistingNoteTitleToMatchAnotherNoteDestroysItsContent();
+
+    /* Follow-up fixes for pbek's review comments on this PR */
+    void testFetchByFileNameExcludesGivenNoteIdAmongDuplicates();
+    void testCanWriteToNoteFileSucceedsWithoutReadPermission();
 };
 
 #endif    // TESTNOTES_H


### PR DESCRIPTION

## Description

Follow-up to #3672 and #3715. While validating #3672 against a real
~7,000-resource Joplin export, I'd noted two small, seemingly cosmetic
follow-ups worth a look someday: a handful of orphaned duplicate attachment
files, and some stale-looking Trash entries tied to duplicate note titles.
Going back to actually fix those turned into something more useful than
expected — the "stale Trash entries" turned out to be the visible aftermath
of a real content-loss bug that isn't specific to Joplin import at all. I
had Claude Code dig into it; it traced the whole thing down to two small,
unrelated-looking issues in `Note` that combine destructively, wrote
regression tests for it, and put this PR together.

## What this changes

### The core bug: `Note::handleNoteTextFileName()`'s duplicate-name check looks at the wrong subfolder

Its collision-avoidance loop calls `Note::fetchByFileName(fileName)` with no
subfolder argument. That defaults to `NoteSubFolder::activeNoteSubFolderId()`
— whatever subfolder happens to be selected in the UI — rather than the
subfolder the note actually being saved/renamed into. During a Joplin import
into a specific target notebook (or really, any time the active subfolder
differs from the note's own), two notes with an identical name in the same
*real* subfolder aren't detected as colliding, because the check is looking
in the wrong place.

**Fix:** pass the note's own `_noteSubFolderId` explicitly, matching the
pattern already used elsewhere in the same file (e.g.
`fetchByRelativeFilePath()`).

### Compounding it: `Note::canWriteToNoteFile()`'s writability probe destroys the file it's checking

Once the wrong-scope check lets a collision through, `handleNoteTextFileName()`
calls `canWriteToNoteFile()` on the (colliding) target path to confirm it's
writable. That function opens the file with `QIODevice::WriteOnly`, which
for `QFile` implies `Truncate` unless combined with `Append` — so merely
*checking* whether an existing file can be written to empties it right there,
before the second note's own write ever happens. The existing
"clean up if it didn't exist before" logic never caught this either, since
it checked `file.exists()` *after* the `open()` call had already created the
file.

**Fix:** capture existence before opening (fixing the ordering above, so the
cleanup finally runs), and open `ReadWrite` instead of `WriteOnly`. When the
target doesn't exist yet, behavior is unchanged: the probe creates a
temporary file to verify writability and then removes it, leaving nothing
behind. When the target *does* already exist, opening `ReadWrite` no longer
wipes its content just to check.

### Same wrong-scope pattern in `Note::renameNoteFile()`

The dedicated "rename note" action (and the scripting API's rename) has the
identical unscoped `Note::fetchByName(newName)` call. It doesn't cause data
loss the same way — I checked directly, and Qt's `QFile::rename()` safely
refuses when the destination already exists — but the wrong-scope check lets
`_fileName`/`_name`/`store()` run before that refusal, leaving the note's DB
row briefly claiming a filename that isn't actually what's on disk. Fixed
the same way, scoped to the note's own subfolder.

### One more found while fixing the first: suffix escalation on repeated calls

`handleNoteTextFileName()` gets called again from every
`storeNoteTextFileToDisk()` (up to a few times per note during import, once
per content/image/attachment pass). Since a note's title line is
deliberately never rewritten with its resolved suffix, "name" recomputed
from the text keeps not matching the already-suffixed `_name` on every later
call, re-entering the collision loop — and once correctly scoped, that loop
would find the note's *own* just-chosen name as a "collision" and escalate
past it (`Title 1` → `Title 2` → ...) every time. Fixed by excluding the
note's own id from the match.

### Also fixed while in the neighborhood: duplicate resource copies during Joplin import

The other half of the original cosmetic report: a Joplin resource
referenced more than once (the same attachment linked twice in a note, or
shared across notes) was copied into the attachments/media folder once per
reference, leaving byte-identical `<id>-1.ext` duplicates. For images,
`Note::getInsertMediaMarkdown()` already has a same-file-reuse mechanism
gated behind a "use existing file?" dialog — the import now sets that
override for its duration (restored afterward) so it reuses automatically
instead of prompting once per repeat. For attachments (no such mechanism
exists), the import dialog now caches the destination filename per resource
id and reuses it directly.

## Why this isn't just a Joplin-import quirk

The wrong-scope check lives in general `Note` code, reachable without any
import: simply editing an *existing* note's title (QOwnNotes derives a
note's name from its own first line) to match another note that already
lives in the *same* subfolder goes through the same
`storeNoteTextFileToDisk()` → `handleNoteTextFileName()` →
`canWriteToNoteFile()` path and destroys that other note's content the same
way — as long as that shared subfolder isn't the one currently active in the
sidebar at the moment you save. If it *is* the active one, the check happens
to look in the right place anyway and correctly refuses the collision.

Added a regression test for exactly that (no import involved at all)
alongside the import-specific one.

## Validation

- Added 4 new tests to the project's own `tests/unit_tests` suite (the same
  suite `build-test.yml` already runs in CI): the import-shaped collision
  fix itself, a regression check confirming collision detection still works
  correctly in the case that already worked (same subfolder *and* active),
  the plain-title-edit case below, and the `renameNoteFile()` fix. All pass;
  the 45 pre-existing tests in the suite are unaffected.
- Manual side-by-side comparison: built patched and unpatched binaries from
  the identical base commit, imported the attached repro into both under
  otherwise-identical fresh sessions.
  - Unpatched: `Team Standup` ends up with only 2 of its 3 notes — the
    "Meeting Notes" note with Alice/Bob's action items is gone entirely, not
    even recoverable from Trash (the destructive step happens before the
    app's own delete-to-trash path ever runs). `attachments/` gets two
    copies of the one linked resource.
  - Patched: all 3 `Team Standup` notes present (`Meeting Notes.md` and
    `Meeting Notes 1.md` correctly separated, each with its own action
    items, plus `Offsite Planning.md`), the separate-notebook `Personal
    Journal` note untouched, and exactly one copy of the resource in
    `attachments/`.
- Manual non-import reproduction, to confirm this really isn't a Joplin-import
  quirk: two subfolders, FolderA and FolderB. In FolderA, create "1st" with
  body "this is the first note" and "2nd" with body "this is the second
  note". With "2nd" still open in the editor, select FolderB (so it's now
  the active subfolder, while both notes still live in FolderA), then
  retitle "2nd" to "1st". On unpatched `main`, that plays out
  destructively in stages:
  1. The moment the rename saves, "2nd"'s content vanishes from the open
     editor — blank. The wrong-scope check let "2nd" claim "1st"'s exact
     name/filename, `canWriteToNoteFile()` truncates the real `1st.md` to
     empty as a side effect of merely checking it's writable, and the
     following disk write lands in a state briefly inconsistent with what
     the UI has open.
  2. Clicking back into FolderA, both notes are now listed as "1st" — but at
     this exact moment, each still shows its own correct, distinct content.
     Nothing has actually been lost yet: "2nd"'s own DB record is
     self-consistent (new name, its own real content), and "1st"'s original
     DB record was never touched — only the *file* backing it got silently
     swapped out from under it.
  3. Whenever the app next rescans notes from disk for that subfolder (the
     exact trigger wasn't pinned down — folder/note navigation seemed to be
     enough), the two duplicate-named notes converge: both now show "2nd"'s
     content. Two DB rows are claiming the identical filename in the
     identical subfolder, which nothing prevents, so whichever one the
     rescan binds to the one real file on disk gets its cached content
     refreshed to match what's actually there, and the other just keeps
     whatever it last held.
  4. End state: two notes, both named "1st", both showing "this is the
     second note." The first note's real content is gone — not in Trash,
     just gone, since the destructive step (stage 1) happens before the
     app's own delete-to-trash path ever runs.

  On the patched build, none of this happens: the collision is caught up
  front, "2nd" is silently suffixed to `1st 1.md` (filename only — its own
  title text stays "1st", which is QOwnNotes' existing, deliberate behavior
  of never rewriting a note's authored first line to match its
  disambiguated filename), and "1st" is untouched throughout.

## Repro data

Small synthetic Joplin RAW export, no real data — 2 notebooks, 4 notes, 1
resource. Attached as `repro-duplicate-titles.zip`. Import via "Import notes
from Joplin" with "Import folders" checked:
- `Team Standup` has two notes titled "Meeting Notes" (recurring-meeting
  notes sharing a generic title, plus one note linking the same attachment
  twice).
- `Personal Journal` has a third note also titled "Meeting Notes" — a
  control to confirm the fix doesn't over-trigger across notebooks that
  aren't actually colliding.

On unpatched `main`, one of the two `Team Standup` "Meeting Notes" is lost
outright, and the attachments folder gets a duplicate file. With this patch,
all three notes come through as their own file, and there's exactly one
copy of the attachment. This is really the most useful part of the PR if
you'd rather approach the fix a different way.

[repro-duplicate-titles.zip](https://github.com/user-attachments/files/31869356/repro-duplicate-titles.zip)
