### PR TITLE
Fix Joplin import resource dedup for MIME-mismatched extensions (follow-up to #3726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 26.9.5
 
+- Fixed duplicate resource files being created during Joplin imports when a
+  resource's file extension differs from Qt's MIME-derived canonical suffix
+  (for [#3736](https://github.com/pbek/QOwnNotes/pull/3736))
 - Internal note links like `[QOwnNotes Android Done](QOwnNotes%20Android%20Done.md)` are now
   styled like external links, where the note file name is grayed out while the link text keeps
   the internal link color (for [#3735](https://github.com/pbek/QOwnNotes/issues/3735))

--- a/src/dialogs/joplinimportdialog.cpp
+++ b/src/dialogs/joplinimportdialog.cpp
@@ -485,59 +485,79 @@ void JoplinImportDialog::handleImages(Note& note, const QString& dirPath) {
     // bracket (`\]`) inside the alt text -- common in web-clipped or OCR'd
     // content -- doesn't prematurely end the capture and make the whole
     // pattern fail to match.
+    //
+    // Each block below re-searches noteText from a moving offset and
+    // replaces only the specific occurrence just matched (by position), then
+    // resumes searching from right after the replacement. Matching against a
+    // one-time globalMatch() snapshot while mutating noteText as we go (the
+    // previous approach) breaks whenever the exact same image tag text
+    // appears more than once in a note: QString::replace(needle, replacement)
+    // replaces every occurrence of the needle at once, so the first match's
+    // replacement also silently consumes every later match's tag text,
+    // leaving their imported files orphaned (imported, but never linked).
     {
-        auto i =
-            QRegularExpression(R"regex(!\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\s+"([^"]*)"\))regex")
-                .globalMatch(noteText);
+        const QRegularExpression re(
+            R"regex(!\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\s+"([^"]*)"\))regex");
+        int searchOffset = 0;
+        QRegularExpressionMatch match = re.match(noteText, searchOffset);
 
-        while (i.hasNext()) {
-            QRegularExpressionMatch match = i.next();
-            QString imageTag = match.captured(0);
+        while (match.hasMatch()) {
             QString imageName = match.captured(1);
             QString imageId = match.captured(2);
             QString hoverText = match.captured(3);
 
             // Use hover text as image name if no alt text is provided
             QString finalImageName = imageName.isEmpty() ? hoverText : imageName;
-            importImage(note, dirPath, noteText, imageTag, imageId, finalImageName);
+            searchOffset = importImage(note, dirPath, noteText, match.capturedStart(0),
+                                       match.capturedLength(0), imageId, finalImageName);
+            match = re.match(noteText, searchOffset);
         }
     }
 
     // Handle format: ![alt text](:/imageId)
     {
-        auto i =
-            QRegularExpression(R"(!\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\))").globalMatch(noteText);
+        const QRegularExpression re(R"(!\[((?:\\.|[^\]])*)\]\(:\/([\w\d]+)\))");
+        int searchOffset = 0;
+        QRegularExpressionMatch match = re.match(noteText, searchOffset);
 
-        while (i.hasNext()) {
-            QRegularExpressionMatch match = i.next();
-            QString imageTag = match.captured(0);
+        while (match.hasMatch()) {
             QString imageName = match.captured(1);
             QString imageId = match.captured(2);
 
-            importImage(note, dirPath, noteText, imageTag, imageId, imageName);
+            searchOffset = importImage(note, dirPath, noteText, match.capturedStart(0),
+                                       match.capturedLength(0), imageId, imageName);
+            match = re.match(noteText, searchOffset);
         }
     }
 
     // Handle format: <img src=":/imageId" ... />
     {
-        auto i = QRegularExpression(R"(<img\s+(?:[^>]*\s+)?src=\":\/([\w\d]+)\"[^>]*\/?>)")
-                     .globalMatch(noteText);
+        const QRegularExpression re(R"(<img\s+(?:[^>]*\s+)?src=\":\/([\w\d]+)\"[^>]*\/?>)");
+        int searchOffset = 0;
+        QRegularExpressionMatch match = re.match(noteText, searchOffset);
 
-        while (i.hasNext()) {
-            QRegularExpressionMatch match = i.next();
-            QString imageTag = match.captured(0);
+        while (match.hasMatch()) {
             QString imageId = match.captured(1);
 
-            importImage(note, dirPath, noteText, imageTag, imageId);
+            searchOffset = importImage(note, dirPath, noteText, match.capturedStart(0),
+                                       match.capturedLength(0), imageId);
+            match = re.match(noteText, searchOffset);
         }
     }
 
     note.setNoteText(noteText);
 }
 
-void JoplinImportDialog::importImage(Note& note, const QString& dirPath, QString& noteText,
-                                     const QString& imageTag, const QString& imageId,
-                                     const QString& imageName) {
+/**
+ * Imports the image/resource for a single matched image tag and replaces
+ * just that occurrence (identified by position, not by tag text) with the
+ * generated Markdown.
+ *
+ * @return the offset handleImages() should resume searching from
+ */
+int JoplinImportDialog::importImage(Note& note, const QString& dirPath, QString& noteText,
+                                    int matchStart, int matchLength, const QString& imageId,
+                                    const QString& imageName) {
     QString imageData = _imageData[imageId];
 
     // Joplin resources are classified as image vs. attachment purely by their
@@ -558,13 +578,17 @@ void JoplinImportDialog::importImage(Note& note, const QString& dirPath, QString
     qDebug() << __func__ << " - 'mediaFile': " << mediaFile;
 
     if (mediaFile == nullptr) {
-        return;
+        // Nothing to import -- leave the tag as-is and just skip past it, so
+        // the caller doesn't re-match this exact spot forever.
+        return matchStart + matchLength;
     }
 
     QString mediaMarkdown = note.getInsertMediaMarkdown(mediaFile, false, false, imageName);
 
     qDebug() << __func__ << " - 'mediaMarkdown': " << mediaMarkdown;
-    noteText.replace(imageTag, mediaMarkdown);
+    noteText.replace(matchStart, matchLength, mediaMarkdown);
+
+    return matchStart + mediaMarkdown.length();
 }
 
 /**

--- a/src/dialogs/joplinimportdialog.h
+++ b/src/dialogs/joplinimportdialog.h
@@ -15,6 +15,10 @@ class QFile;
 class JoplinImportDialog : public MasterDialog {
     Q_OBJECT
 
+    // Lets the unit test suite exercise handleImages() directly against a
+    // crafted note/resource, instead of only via a full interactive import.
+    friend class TestNotes;
+
     struct MediaFileData {
         QString data;
         QString suffix;
@@ -56,8 +60,8 @@ class JoplinImportDialog : public MasterDialog {
     void handleAttachments(Note& note, const QString& dirPath);
     bool importFolders();
     NoteSubFolder importFolder(const QString& id, const QString& text);
-    void importImage(Note& note, const QString& dirPath, QString& noteText, const QString& imageTag,
-                     const QString& imageId, const QString& imageName = "");
+    int importImage(Note& note, const QString& dirPath, QString& noteText, int matchStart,
+                    int matchLength, const QString& imageId, const QString& imageName = "");
     static QFile* findResourceFile(const QString& dirPath, const QString& id,
                                    const QString& metaData);
 };

--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -6300,13 +6300,26 @@ QString Note::getInsertMediaMarkdown(QFile *file, bool addNewLine, bool returnUr
         }
     }
 
+    // The name findAvailableFileName() would give this file on a first (no
+    // collision) pass -- base name plus the MIME-normalized suffix, not
+    // necessarily the source file's own suffix. The existence check below
+    // must test for *this* name: the file actually gets written with
+    // `suffix`, so probing for file->fileName()'s original extension instead
+    // (e.g. ".jpeg" when the MIME type normalizes to ".jpg") would never
+    // find a match and duplicate-import every repeat reference to the same
+    // resource.
+    QString candidateBaseName = fileInfo.baseName();
+    candidateBaseName.truncate(200);
+    const QString candidateFileName =
+        suffix.isEmpty() ? candidateBaseName : candidateBaseName + QLatin1Char('.') + suffix;
+
     bool useExistingFile = false;
     // check if image with the same name already exists in media folder
-    if (Utils::Misc::fileNameExists(file->fileName(), mediaDir.path())) {
+    if (Utils::Misc::fileNameExists(candidateFileName, mediaDir.path())) {
         // file->fileName() wields a path!
         auto fileHash = Utils::Misc::generateFileSha1Signature(file->fileName());
         auto newFileHash = Utils::Misc::generateFileSha1Signature(
-            mediaDir.path() + QDir::separator() + Utils::Misc::fileNameForPath(file->fileName()));
+            mediaDir.path() + QDir::separator() + candidateFileName);
 
         // check if files are binary identical and ask if we want to use the existing file
         if (fileHash == newFileHash &&
@@ -6322,9 +6335,10 @@ QString Note::getInsertMediaMarkdown(QFile *file, bool addNewLine, bool returnUr
     }
 
     // find a name for the new file
-    const QString newFileName = useExistingFile ? Utils::Misc::fileNameForPath(file->fileName())
-                                                : Utils::Misc::findAvailableFileName(
-                                                      file->fileName(), mediaDir.path(), suffix);
+    const QString newFileName = useExistingFile
+                                    ? candidateFileName
+                                    : Utils::Misc::findAvailableFileName(file->fileName(),
+                                                                         mediaDir.path(), suffix);
 
     const QString newFilePath = mediaDir.path() + QDir::separator() + newFileName;
 

--- a/src/entities/note.cpp
+++ b/src/entities/note.cpp
@@ -6335,10 +6335,9 @@ QString Note::getInsertMediaMarkdown(QFile *file, bool addNewLine, bool returnUr
     }
 
     // find a name for the new file
-    const QString newFileName = useExistingFile
-                                    ? candidateFileName
-                                    : Utils::Misc::findAvailableFileName(file->fileName(),
-                                                                         mediaDir.path(), suffix);
+    const QString newFileName = useExistingFile ? candidateFileName
+                                                : Utils::Misc::findAvailableFileName(
+                                                      file->fileName(), mediaDir.path(), suffix);
 
     const QString newFilePath = mediaDir.path() + QDir::separator() + newFileName;
 

--- a/tests/unit_tests/testcases/app/app-tests.pri
+++ b/tests/unit_tests/testcases/app/app-tests.pri
@@ -35,6 +35,8 @@ HEADERS  += \
     $$APP_SRC_DIR/services/settingsservice.h \
     $$APP_SRC_DIR/services/cloudservice.h \
     $$APP_SRC_DIR/dialogs/masterdialog.h \
+    $$APP_SRC_DIR/dialogs/filedialog.h \
+    $$APP_SRC_DIR/dialogs/joplinimportdialog.h \
     $$APP_SRC_DIR/widgets/navigationwidget.h \
     $$APP_SRC_DIR/widgets/logwidget.h \
     $$APP_SRC_DIR/entities/notefolder.h \
@@ -96,6 +98,8 @@ SOURCES += \
     $$APP_SRC_DIR/services/settingsservice.cpp \
     $$APP_SRC_DIR/services/cloudservice.cpp \
     $$APP_SRC_DIR/dialogs/masterdialog.cpp \
+    $$APP_SRC_DIR/dialogs/filedialog.cpp \
+    $$APP_SRC_DIR/dialogs/joplinimportdialog.cpp \
     $$APP_SRC_DIR/widgets/navigationwidget.cpp \
     $$APP_SRC_DIR/widgets/logwidget.cpp \
     $$APP_SRC_DIR/entities/notefolder.cpp \
@@ -127,7 +131,8 @@ SOURCES += \
     $$APP_SRC_DIR/threads/scriptthread.cpp \
 
 FORMS += \
-    $$APP_SRC_DIR/libraries/qmarkdowntextedit/qplaintexteditsearchwidget.ui
+    $$APP_SRC_DIR/libraries/qmarkdowntextedit/qplaintexteditsearchwidget.ui \
+    $$APP_SRC_DIR/dialogs/joplinimportdialog.ui
 
 include($$APP_SRC_DIR/libraries/botan/botan.pri)
 

--- a/tests/unit_tests/testcases/app/test_notes.cpp
+++ b/tests/unit_tests/testcases/app/test_notes.cpp
@@ -14,8 +14,10 @@
 #include <QUuid>
 #include <QtTest>
 
+#include "dialogs/joplinimportdialog.h"
 #include "entities/bookmark.h"
 #include "entities/commandsnippet.h"
+#include "entities/notefolder.h"
 #include "entities/notesubfolder.h"
 #include "entities/trashitem.h"
 #include "services/settingsservice.h"
@@ -110,6 +112,21 @@ void TestNotes::initTestCase() {
     settings.setValue(QStringLiteral("notesPath"), notesPath);
     wikiLinkSupportSetting = settings.value(QStringLiteral("Editor/wikiLinkSupport"));
     settings.setValue(QStringLiteral("Editor/wikiLinkSupport"), false);
+
+    // A current NoteFolder DB row is needed for NoteFolder::currentMediaPath()
+    // (used by Note::getInsertMediaMarkdown()) to resolve to notesPath/media
+    // instead of an empty/unfetched path. Setting "currentNoteFolderId"
+    // directly (rather than via NoteFolder::setAsCurrent()) avoids that
+    // method's CloudService::instance(true) reset, which constructs a
+    // QNetworkAccessManager -- unnecessary here, and prone to hanging this
+    // offscreen/no-network test environment.
+    NoteFolder testNoteFolder;
+    testNoteFolder.setName(QStringLiteral("Test Note Folder"));
+    testNoteFolder.setLocalPath(notesPath);
+    if (!testNoteFolder.store()) {
+        qFatal("Failed to store note folder in test setup");
+    }
+    settings.setValue(QStringLiteral("currentNoteFolderId"), testNoteFolder.getId());
 
     // create a note file
     noteName = QStringLiteral("MyTestNote");
@@ -1780,6 +1797,134 @@ void TestNotes::testCanWriteToNoteFileSucceedsWithoutReadPermission() {
 #else
     QSKIP("POSIX permission bits test only applies on unix-like platforms");
 #endif
+}
+
+/**
+ * Regression test for the Joplin-import resource-dedup follow-up to #3726:
+ * Note::getInsertMediaMarkdown()'s "does this file already exist" check used
+ * to probe for the source file's own extension, even though it may write the
+ * file under Qt's MIME-derived canonical suffix instead (".jpeg" source ->
+ * ".jpg" written, ".htm" -> ".html", etc.). That mismatch meant the check
+ * could never succeed once the suffix had been normalized even once, so
+ * every later reference to the same resource minted a fresh byte-identical
+ * "<name>-1.<ext>" duplicate instead of reusing the first copy.
+ */
+void TestNotes::testGetInsertMediaMarkdownReusesFileDespiteMimeExtensionMismatch() {
+    Note note = createTestNote(uniqueTestName(QStringLiteral("Mime Suffix Note")));
+
+    SettingsService settings;
+    const QVariant previousOverride =
+        settings.value(QStringLiteral("MessageBoxOverride/insert-media-use-existing-image"));
+    // Force "always reuse the existing file", matching what
+    // JoplinImportDialog::on_importButton_clicked() does for the whole
+    // import, so this test doesn't block on a real message box.
+    settings.setValue(QStringLiteral("MessageBoxOverride/insert-media-use-existing-image"),
+                      QMessageBox::Yes);
+
+    // ".jpeg" is a real image/jpeg file extension, but Qt's MIME database
+    // normalizes image/jpeg's canonical suffix to "jpg" -- exactly the
+    // mismatch this bug needs to trigger.
+    const QString sourceBaseName = uniqueTestName(QStringLiteral("resource"));
+    const QString sourcePath =
+        QDir::tempPath() + QDir::separator() + sourceBaseName + QStringLiteral(".jpeg");
+    QFile sourceSetupFile(sourcePath);
+    QVERIFY(sourceSetupFile.open(QIODevice::WriteOnly));
+    sourceSetupFile.write(QByteArrayLiteral("not real jpeg bytes, just needs to be non-empty"));
+    sourceSetupFile.close();
+
+    const QDir mediaDir(NoteFolder::currentMediaPath());
+
+    QFile firstReference(sourcePath);
+    const QString firstMarkdown = note.getInsertMediaMarkdown(&firstReference, false, false);
+    QVERIFY2(!firstMarkdown.isEmpty(), "first reference must produce a media link");
+    QCOMPARE(mediaDir.entryList({sourceBaseName + QStringLiteral("*")}, QDir::Files).count(), 1);
+
+    QFile secondReference(sourcePath);
+    const QString secondMarkdown = note.getInsertMediaMarkdown(&secondReference, false, false);
+    QVERIFY2(!secondMarkdown.isEmpty(), "second reference must still produce a media link");
+
+    QVERIFY2(mediaDir.entryList({sourceBaseName + QStringLiteral("*")}, QDir::Files).count() == 1,
+             "a second reference to the same resource must reuse the existing media file, not "
+             "mint a '-1' duplicate");
+    QCOMPARE(secondMarkdown, firstMarkdown);
+
+    QVERIFY(QFile::remove(sourcePath));
+    if (previousOverride.isValid()) {
+        settings.setValue(QStringLiteral("MessageBoxOverride/insert-media-use-existing-image"),
+                          previousOverride);
+    } else {
+        settings.remove(QStringLiteral("MessageBoxOverride/insert-media-use-existing-image"));
+    }
+}
+
+/**
+ * Regression test for the compounding orphan bug in
+ * JoplinImportDialog::handleImages(): when the exact same image tag appears
+ * more than once in a single note, the old code matched all occurrences
+ * against a one-time text snapshot but replaced them with
+ * `noteText.replace(imageTag, mediaMarkdown)`, which rewrites every
+ * occurrence of that literal tag text at once on the first match. Every
+ * later match still ran importImage() (writing another duplicate file, given
+ * the bug above) but its markdown was never actually inserted anywhere --
+ * silently orphaning the file.
+ *
+ * handleImages() and importImage() are private, so this test is declared a
+ * friend of JoplinImportDialog (see joplinimportdialog.h) to call them
+ * directly against a crafted note and resource, without needing to drive the
+ * whole interactive import dialog.
+ */
+void TestNotes::testHandleImagesDoesNotOrphanRepeatedIdenticalImageTagInSameNote() {
+    SettingsService settings;
+    const QVariant previousOverride =
+        settings.value(QStringLiteral("MessageBoxOverride/insert-media-use-existing-image"));
+    settings.setValue(QStringLiteral("MessageBoxOverride/insert-media-use-existing-image"),
+                      QMessageBox::Yes);
+
+    const QString resourceBaseName = uniqueTestName(QStringLiteral("resource"));
+    const QString resourceId = uniqueTestName(QStringLiteral("id")).remove(QLatin1Char('-'));
+
+    const QString dirPath = QDir::tempPath() + QDir::separator() +
+                            uniqueTestName(QStringLiteral("joplin-export"));
+    QDir().mkpath(dirPath + QStringLiteral("/resources"));
+    const QString resourcePath =
+        dirPath + QStringLiteral("/resources/") + resourceId + QStringLiteral(".jpeg");
+    QFile resourceFile(resourcePath);
+    QVERIFY(resourceFile.open(QIODevice::WriteOnly));
+    resourceFile.write(QByteArrayLiteral("not real jpeg bytes, just needs to be non-empty"));
+    resourceFile.close();
+
+    Note note = createTestNote(uniqueTestName(QStringLiteral("Repeated Image Note")));
+    const QString imageTag =
+        QStringLiteral("![%1](:/%2)").arg(resourceBaseName, resourceId);
+    note.setNoteText(QStringLiteral("# Repeated Image\n\n%1\n\nSome text in between.\n\n%1\n")
+                         .arg(imageTag));
+
+    JoplinImportDialog dialog;
+    dialog._imageData.insert(resourceId, QStringLiteral("mime: image/jpeg\n"));
+    dialog.handleImages(note, dirPath);
+
+    const QDir mediaDir(NoteFolder::currentMediaPath());
+    QVERIFY2(
+        mediaDir.entryList({resourceId + QStringLiteral("*")}, QDir::Files).count() == 1,
+        "two identical references to the same resource in one note must not create a '-1' "
+        "duplicate file");
+
+    const QString resultText = note.getNoteText();
+    QVERIFY2(!resultText.contains(imageTag),
+             "both occurrences of the image tag must have been replaced with markdown");
+    const int linkCount = resultText.count(QStringLiteral("](../media/"))  +
+                          resultText.count(QStringLiteral("](media/"));
+    QVERIFY2(linkCount == 2,
+             "both occurrences must produce a link -- the second one must not be silently "
+             "dropped/orphaned");
+
+    QVERIFY(QDir(dirPath).removeRecursively());
+    if (previousOverride.isValid()) {
+        settings.setValue(QStringLiteral("MessageBoxOverride/insert-media-use-existing-image"),
+                          previousOverride);
+    } else {
+        settings.remove(QStringLiteral("MessageBoxOverride/insert-media-use-existing-image"));
+    }
 }
 
 // QTEST_MAIN(TestNotes)

--- a/tests/unit_tests/testcases/app/test_notes.cpp
+++ b/tests/unit_tests/testcases/app/test_notes.cpp
@@ -1927,4 +1927,45 @@ void TestNotes::testHandleImagesDoesNotOrphanRepeatedIdenticalImageTagInSameNote
     }
 }
 
+/**
+ * Regression test for a case an automated review flagged as a suspected
+ * infinite loop: when a matched resource is zero bytes,
+ * getInsertMediaMarkdown() returns an empty string, and importImage()'s
+ * resume offset is computed as matchStart + mediaMarkdown.length() ==
+ * matchStart. That looks like it could re-match the same spot forever, but
+ * it doesn't: noteText.replace(matchStart, matchLength, "") still removes
+ * the matched tag text, shifting whatever followed it back to matchStart, so
+ * the next search from matchStart finds new content, not the same tag.
+ * Verified empirically here (two zero-byte-resource tags in one note) rather
+ * than left as an unconfirmed concern; QtTest's 5-minute per-test timeout
+ * would fail this with "Test function timed out" if the loop were real.
+ */
+void TestNotes::testHandleImagesTerminatesOnZeroByteResource() {
+    const QString resourceId = uniqueTestName(QStringLiteral("id")).remove(QLatin1Char('-'));
+
+    const QString dirPath = QDir::tempPath() + QDir::separator() +
+                            uniqueTestName(QStringLiteral("joplin-export-zero"));
+    QDir().mkpath(dirPath + QStringLiteral("/resources"));
+    const QString resourcePath =
+        dirPath + QStringLiteral("/resources/") + resourceId + QStringLiteral(".jpeg");
+    QFile resourceFile(resourcePath);
+    QVERIFY(resourceFile.open(QIODevice::WriteOnly));
+    resourceFile.close();    // zero bytes
+
+    Note note = createTestNote(uniqueTestName(QStringLiteral("Zero Byte Resource Note")));
+    const QString imageTag = QStringLiteral("![zero](:/%1)").arg(resourceId);
+    note.setNoteText(QStringLiteral("# Zero Byte\n\n%1\n\nSome text in between.\n\n%1\nTail.\n")
+                         .arg(imageTag));
+
+    JoplinImportDialog dialog;
+    dialog._imageData.insert(resourceId, QStringLiteral("mime: image/jpeg\n"));
+    dialog.handleImages(note, dirPath);
+
+    QVERIFY2(!note.getNoteText().contains(imageTag),
+             "both zero-byte-resource tags must have been removed, not left in an infinite loop");
+    QVERIFY(note.getNoteText().contains(QStringLiteral("Tail.")));
+
+    QVERIFY(QDir(dirPath).removeRecursively());
+}
+
 // QTEST_MAIN(TestNotes)

--- a/tests/unit_tests/testcases/app/test_notes.cpp
+++ b/tests/unit_tests/testcases/app/test_notes.cpp
@@ -1883,8 +1883,8 @@ void TestNotes::testHandleImagesDoesNotOrphanRepeatedIdenticalImageTagInSameNote
     const QString resourceBaseName = uniqueTestName(QStringLiteral("resource"));
     const QString resourceId = uniqueTestName(QStringLiteral("id")).remove(QLatin1Char('-'));
 
-    const QString dirPath = QDir::tempPath() + QDir::separator() +
-                            uniqueTestName(QStringLiteral("joplin-export"));
+    const QString dirPath =
+        QDir::tempPath() + QDir::separator() + uniqueTestName(QStringLiteral("joplin-export"));
     QDir().mkpath(dirPath + QStringLiteral("/resources"));
     const QString resourcePath =
         dirPath + QStringLiteral("/resources/") + resourceId + QStringLiteral(".jpeg");
@@ -1894,25 +1894,23 @@ void TestNotes::testHandleImagesDoesNotOrphanRepeatedIdenticalImageTagInSameNote
     resourceFile.close();
 
     Note note = createTestNote(uniqueTestName(QStringLiteral("Repeated Image Note")));
-    const QString imageTag =
-        QStringLiteral("![%1](:/%2)").arg(resourceBaseName, resourceId);
-    note.setNoteText(QStringLiteral("# Repeated Image\n\n%1\n\nSome text in between.\n\n%1\n")
-                         .arg(imageTag));
+    const QString imageTag = QStringLiteral("![%1](:/%2)").arg(resourceBaseName, resourceId);
+    note.setNoteText(
+        QStringLiteral("# Repeated Image\n\n%1\n\nSome text in between.\n\n%1\n").arg(imageTag));
 
     JoplinImportDialog dialog;
     dialog._imageData.insert(resourceId, QStringLiteral("mime: image/jpeg\n"));
     dialog.handleImages(note, dirPath);
 
     const QDir mediaDir(NoteFolder::currentMediaPath());
-    QVERIFY2(
-        mediaDir.entryList({resourceId + QStringLiteral("*")}, QDir::Files).count() == 1,
-        "two identical references to the same resource in one note must not create a '-1' "
-        "duplicate file");
+    QVERIFY2(mediaDir.entryList({resourceId + QStringLiteral("*")}, QDir::Files).count() == 1,
+             "two identical references to the same resource in one note must not create a '-1' "
+             "duplicate file");
 
     const QString resultText = note.getNoteText();
     QVERIFY2(!resultText.contains(imageTag),
              "both occurrences of the image tag must have been replaced with markdown");
-    const int linkCount = resultText.count(QStringLiteral("](../media/"))  +
+    const int linkCount = resultText.count(QStringLiteral("](../media/")) +
                           resultText.count(QStringLiteral("](media/"));
     QVERIFY2(linkCount == 2,
              "both occurrences must produce a link -- the second one must not be silently "
@@ -1943,8 +1941,8 @@ void TestNotes::testHandleImagesDoesNotOrphanRepeatedIdenticalImageTagInSameNote
 void TestNotes::testHandleImagesTerminatesOnZeroByteResource() {
     const QString resourceId = uniqueTestName(QStringLiteral("id")).remove(QLatin1Char('-'));
 
-    const QString dirPath = QDir::tempPath() + QDir::separator() +
-                            uniqueTestName(QStringLiteral("joplin-export-zero"));
+    const QString dirPath =
+        QDir::tempPath() + QDir::separator() + uniqueTestName(QStringLiteral("joplin-export-zero"));
     QDir().mkpath(dirPath + QStringLiteral("/resources"));
     const QString resourcePath =
         dirPath + QStringLiteral("/resources/") + resourceId + QStringLiteral(".jpeg");
@@ -1954,8 +1952,8 @@ void TestNotes::testHandleImagesTerminatesOnZeroByteResource() {
 
     Note note = createTestNote(uniqueTestName(QStringLiteral("Zero Byte Resource Note")));
     const QString imageTag = QStringLiteral("![zero](:/%1)").arg(resourceId);
-    note.setNoteText(QStringLiteral("# Zero Byte\n\n%1\n\nSome text in between.\n\n%1\nTail.\n")
-                         .arg(imageTag));
+    note.setNoteText(
+        QStringLiteral("# Zero Byte\n\n%1\n\nSome text in between.\n\n%1\nTail.\n").arg(imageTag));
 
     JoplinImportDialog dialog;
     dialog._imageData.insert(resourceId, QStringLiteral("mime: image/jpeg\n"));

--- a/tests/unit_tests/testcases/app/test_notes.h
+++ b/tests/unit_tests/testcases/app/test_notes.h
@@ -8,6 +8,7 @@
 #include <QVariant>
 
 #include "entities/note.h"
+#include "entities/notefolder.h"
 #include "entities/notesubfolder.h"
 
 class TestNotes : public QObject {
@@ -101,6 +102,10 @@ class TestNotes : public QObject {
     /* Follow-up fixes for pbek's review comments on this PR */
     void testFetchByFileNameExcludesGivenNoteIdAmongDuplicates();
     void testCanWriteToNoteFileSucceedsWithoutReadPermission();
+
+    /* Joplin-import image resource dedup, follow-up to #3726 */
+    void testGetInsertMediaMarkdownReusesFileDespiteMimeExtensionMismatch();
+    void testHandleImagesDoesNotOrphanRepeatedIdenticalImageTagInSameNote();
 };
 
 #endif    // TESTNOTES_H

--- a/tests/unit_tests/testcases/app/test_notes.h
+++ b/tests/unit_tests/testcases/app/test_notes.h
@@ -106,6 +106,7 @@ class TestNotes : public QObject {
     /* Joplin-import image resource dedup, follow-up to #3726 */
     void testGetInsertMediaMarkdownReusesFileDespiteMimeExtensionMismatch();
     void testHandleImagesDoesNotOrphanRepeatedIdenticalImageTagInSameNote();
+    void testHandleImagesTerminatesOnZeroByteResource();
 };
 
 #endif    // TESTNOTES_H


### PR DESCRIPTION
## Description

Follow-up to #3726. While validating it I found #3726's resource-dedup fix
only covers plain attachment links (`handleAttachments()`'s resource-ID
cache) — the image-tag path (`handleImages()` → `importImage()` →
`Note::getInsertMediaMarkdown()`) has an independent existence-check issue
that still duplicates a resource whenever its real file extension differs
from Qt's MIME-derived canonical suffix for it (`.jpeg` → `.jpg`, `.htm` →
`.html`, etc.) — common enough in Joplin/browser-clipper exports.

## Root cause

`Note::getInsertMediaMarkdown()`'s "does this file already exist" check
(`src/entities/note.cpp:6276`) computes a MIME-normalized suffix for the
*destination* filename, but the existence check itself still re-derives the
filename from the original source extension and never gets told about the
normalization:

```cpp
const QFileInfo fileInfo(file->fileName());     // file->fileName() = ".../resources/9584....jpeg"
QString suffix = fileInfo.suffix();              // suffix = "jpeg"
QMimeDatabase db;
const QMimeType type = db.mimeTypeForFile(file->fileName());
if (type.isValid() && !type.suffixes().isEmpty()) {
    suffix = type.suffixes().at(0);              // suffix = "jpg"  <- now MIME-normalized
}

bool useExistingFile = false;
if (Utils::Misc::fileNameExists(file->fileName(), mediaDir.path())) {   // <- passes file->fileName() again, not suffix
    ...                                            // checks for "9584....jpeg", never "9584....jpg"
}

const QString newFileName = useExistingFile
    ? ...
    : Utils::Misc::findAvailableFileName(file->fileName(), mediaDir.path(), suffix);  // <- this one does use suffix
```

Walking through two references to the same `.jpeg` resource:

1. **First reference**: existence check
   (`Utils::Misc::fileNameExists(file->fileName(), mediaDir.path())`,
   `src/utils/misc.cpp:2792`) looks for `9584....jpeg` in `media/` — not
   there, so `useExistingFile = false`.
   `Utils::Misc::findAvailableFileName()` (`src/utils/misc.cpp:2737`) is
   handed the correct `suffix` ("jpg"), sees `9584....jpg` doesn't exist
   yet, writes it as `9584....jpg`.
2. **Second reference**: existence check *again* looks for `9584....jpeg`
   — still not there (the file on disk is named `.jpg`, not `.jpeg`) — so
   `useExistingFile = false` *again*, even though the resource was just
   imported. `findAvailableFileName()` now finds `9584....jpg` already
   taken, so it mints `9584-1.jpg`.
3. Repeat for every further reference: `-2`, `-3`, ... — the existence
   check never has a chance to succeed, because it's permanently asking
   about a filename that will never exist once the MIME-normalization has
   kicked in even once.

This never manifests when source and MIME-derived extensions already
match (the common case) — `file->fileName()`'s extension and `suffix` are
the same string there, so the existence check happens to ask the right
question anyway. Confirmed resources referenced 100+ times each with
matching source/MIME extensions dedup correctly to exactly one file, zero
`-N` copies — the extension mismatch is a hard requirement for this to
trigger, not just a common trigger, even though the override
(`MessageBoxOverride/insert-media-use-existing-image`, forced to "Yes" for
the whole import in
`JoplinImportDialog::on_importButton_clicked()`,
`src/dialogs/joplinimportdialog.cpp:136-140`) is meant to guarantee reuse
in every case.

There's a second, compounding effect for resources referenced more than once
*within the same note*: `handleImages()`'s regex loop matches all occurrences
against a snapshot of the note text, but `noteText.replace(imageTag,
mediaMarkdown)` replaces every occurrence of that literal tag text at once on
the first match. So only the first occurrence's generated link actually
survives in the note; every later match in the same loop still runs
`importImage()` (writing yet another duplicate file, given the issue above)
but its resulting link is never inserted anywhere — a fully orphaned file.
This has no visible effect on the note itself either way — repeated
occurrences of a tag always render identically, pointing at the same first
file, both before and after this fix. The only observable difference is the
extra unlinked file sitting in `media/`.

## Impact

No data loss — this failure mode can only add redundant files, since it
only ever fires on the "should I skip the copy" branch, never the "should I
skip the write" branch. It's wasted disk space and, for orphaned copies,
dead weight not linked from anywhere.

## Fix

- `getInsertMediaMarkdown()`'s existence check now uses the same
  MIME-normalized `suffix` it computes for the destination filename,
  instead of `file->fileName()`'s original extension — fixes the
  cross-note/cross-reference duplication.
- `handleImages()`/`importImage()` reworked to search-and-replace by
  position instead of the old snapshot-`globalMatch()` + blanket
  `noteText.replace(tagText, ...)`, so an identical tag appearing more than
  once in one note no longer has its later occurrence's imported file
  silently orphaned.
- Three new regression tests in `tests/unit_tests/testcases/app/test_notes.cpp`:
  `testGetInsertMediaMarkdownReusesFileDespiteMimeExtensionMismatch` and
  `testHandleImagesDoesNotOrphanRepeatedIdenticalImageTagInSameNote` cover the
  two fixes directly; `testHandleImagesTerminatesOnZeroByteResource` was added
  after an automated review raised (and this then disproved, empirically) a
  suspected infinite loop on zero-byte resources.

## Testing

- All 3 new regression tests pass; full `TestNotes` suite passes with no
  regressions. Verified the tests actually catch the issue: reverted just
  the fix, confirmed both dedup tests fail against the old code, restored
  the fix, confirmed they pass.
- Synthetic repro (`repro-mime-mismatch.zip`, attached) covering a control
  case plus both the cross-note dedup issue and the same-note orphan
  compounding issue — imported through the real Joplin import dialog
  side-by-side on an unpatched build and this branch.
- Re-imported a large real-world Joplin export against this branch and
  hash-verified every resource against the source export: all notes and
  resources present and byte-identical, with the duplicate/orphan files seen
  on the unpatched build no longer appearing at all.

## Repro

Attached: `repro-mime-mismatch.zip`. A synthetic Joplin raw-export directory
with:

- a control case (`.png`, matching source/MIME extension, referenced from
  two different notes) — should dedup to one file both before and after the
  fix, confirming this isn't "any repeated resource duplicates"
- a `.jpeg` resource (Qt's canonical suffix for image/jpeg is `jpg`)
  referenced from two different notes — isolates the cross-note dedup issue
  on its own
- a `.htm` resource (canonical suffix `html`) referenced twice with the
  identical `<img>` tag in the *same* note — exercises both the dedup issue
  and the compounding same-note orphan issue in `handleImages()` together.
  Note: both occurrences will look identical and correctly show the image in
  the app either way — the file-count difference in `media/` is what to
  check, not the rendered note.

Import it via QOwnNotes' Joplin import dialog into an empty note folder.
On an unpatched build, the repeated-reference cases each mint a `-1`
duplicate (the same-note one ending up orphaned, unlinked from either
occurrence). On this branch: one file each, correctly reused/linked.

[repro-mime-mismatch.zip](https://github.com/user-attachments/files/32145439/repro-mime-mismatch.zip)

